### PR TITLE
Expose Instance IP addresses as computed fields

### DIFF
--- a/core/instance_resource.go
+++ b/core/instance_resource.go
@@ -81,6 +81,16 @@ func InstanceResource() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"public_ip": {
+				Type:     schema.TypeString,
+				Required: false,
+				Computed: true,
+			},
+			"private_ip": {
+				Type:     schema.TypeString,
+				Required: false,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/core/instance_resource_crud.go
+++ b/core/instance_resource_crud.go
@@ -3,7 +3,11 @@
 package core
 
 import (
+	"log"
+
 	"github.com/MustWin/baremetal-sdk-go"
+
+	"github.com/oracle/terraform-provider-baremetal/options"
 
 	"github.com/oracle/terraform-provider-baremetal/crud"
 )
@@ -11,6 +15,10 @@ import (
 type InstanceResourceCrud struct {
 	crud.BaseCrud
 	Resource *baremetal.Instance
+
+	// Computed fields
+	public_ip  string
+	private_ip string
 }
 
 func (s *InstanceResourceCrud) ID() string {
@@ -74,8 +82,75 @@ func (s *InstanceResourceCrud) Create() (e error) {
 	return
 }
 
+/*
+ * Return the id of the first VNIC attached to this Instance.
+ *
+ * NOTE while the instance is still being created, calls to this function
+ * can return  an error priort to the Vnic being attached.
+ */
+func (s *InstanceResourceCrud) getInstanceVnicId() (vnic_id string, e error) {
+	compartmentID := s.Resource.CompartmentID
+
+	opts := &baremetal.ListVnicAttachmentsOptions{}
+	options.SetListOptions(s.D, &opts.ListOptions)
+	opts.AvailabilityDomain = s.Resource.AvailabilityDomain
+	opts.InstanceID = s.Resource.ID
+
+	var list *baremetal.ListVnicAttachments
+	if list, e = s.Client.ListVnicAttachments(compartmentID, opts); e != nil {
+		return "", e
+	}
+
+	if len(list.Attachments) < 1 {
+		log.Printf("[DEBUG] GetInstanceVnicID - InstanceID: %q, State: %q, no vnic attachments: %q", s.Resource.ID, s.Resource.State, e)
+		return "", e
+	}
+
+	return list.Attachments[0].VnicID, nil
+}
+
+/*
+ * Return the public, private IP pair associated with the instance's first Vnic.
+ *
+ * NOTE while the instance is still being created, calls to this function
+ * can return  an error priort to the Vnic being attached.
+ */
+func (s *InstanceResourceCrud) getInstanceIPs() (public_ip string, private_ip string, e error) {
+	vnicID, e := s.getInstanceVnicId()
+	if e != nil {
+		return "", "", e
+	}
+
+	// Lookup Vnic by id
+	vnic, e := s.Client.GetVnic(vnicID)
+	if e != nil {
+		return "", "", e
+	}
+
+	return vnic.PublicIPAddress, vnic.PrivateIPAddress, nil
+}
+
 func (s *InstanceResourceCrud) Get() (e error) {
 	s.Resource, e = s.Client.GetInstance(s.D.Id())
+
+	if e != nil {
+		return e
+	}
+
+	// Compute instance IPs through attached Vnic
+	// (Not available while state==PROVISIONING)
+	public_ip, private_ip, e2 := s.getInstanceIPs()
+	if e2 != nil {
+		log.Printf("[DEBUG] no vnic yet, skipping")
+	}
+
+	if public_ip != "" {
+		s.public_ip = public_ip
+	}
+	if private_ip != "" {
+		s.private_ip = private_ip
+	}
+
 	return
 }
 
@@ -99,6 +174,9 @@ func (s *InstanceResourceCrud) SetData() {
 	s.D.Set("shape", s.Resource.Shape)
 	s.D.Set("state", s.Resource.State)
 	s.D.Set("time_created", s.Resource.TimeCreated.String())
+
+	s.D.Set("public_ip", s.public_ip)
+	s.D.Set("private_ip", s.private_ip)
 }
 
 func (s *InstanceResourceCrud) Delete() (e error) {

--- a/core_instance_test.go
+++ b/core_instance_test.go
@@ -96,6 +96,37 @@ func (s *ResourceCoreInstanceTestSuite) SetupTest() {
 		"subnetid",
 		opts).Return(s.Res, nil)
 	s.Client.On("TerminateInstance", s.Res.ID, (*baremetal.IfMatchOptions)(nil)).Return(nil)
+
+	listVnicOpts := &baremetal.ListVnicAttachmentsOptions{}
+	listVnicOpts.AvailabilityDomain = s.Res.AvailabilityDomain
+	listVnicOpts.InstanceID = s.Res.ID
+
+	listVnicOpts2 := &baremetal.ListVnicAttachmentsOptions{}
+	listVnicOpts2.AvailabilityDomain = "new_availability_domain"
+	listVnicOpts2.InstanceID = "new_id"
+
+	vnic := &baremetal.Vnic{}
+	vnic.PublicIPAddress = "0.0.0.0"
+	vnic.PrivateIPAddress = "0.0.0.0"
+	vnicAttachment := &baremetal.VnicAttachment{
+		ID:                 "id1",
+		AvailabilityDomain: "availabilityid",
+		CompartmentID:      "compartmentid",
+		DisplayName:        "att1",
+		InstanceID:         "instanceid",
+		State:              baremetal.ResourceAttached,
+		SubnetID:           "subnetid",
+		VnicID:             "vnicid",
+		TimeCreated:        time.Now(),
+	}
+	vnicList := &baremetal.ListVnicAttachments{
+		Attachments: []baremetal.VnicAttachment{
+			*vnicAttachment,
+		},
+	}
+	s.Client.On("ListVnicAttachments", s.Res.CompartmentID, listVnicOpts).Return(vnicList, nil)
+	s.Client.On("ListVnicAttachments", s.Res.CompartmentID, listVnicOpts2).Return(vnicList, nil)
+	s.Client.On("GetVnic", "vnicid").Return(vnic, nil)
 }
 
 func (s *ResourceCoreInstanceTestSuite) TestCreateResourceCoreInstance() {
@@ -117,6 +148,8 @@ func (s *ResourceCoreInstanceTestSuite) TestCreateResourceCoreInstance() {
 					resource.TestCheckResourceAttr(s.ResourceName, "image", s.Res.ImageID),
 					resource.TestCheckResourceAttr(s.ResourceName, "state", s.Res.State),
 					resource.TestCheckResourceAttr(s.ResourceName, "time_created", s.Res.TimeCreated.String()),
+					resource.TestCheckResourceAttr(s.ResourceName, "public_ip", "0.0.0.0"),
+					resource.TestCheckResourceAttr(s.ResourceName, "private_ip", "0.0.0.0"),
 				),
 			},
 		},


### PR DESCRIPTION
This PR exposes the public and private IPs of a compute instance directly as part of the `baremetal_core_instance` resource. The addresses are calculated according to the first Vnic attachment of the instance.

This facilitates interacting with instance clusters, for example:

```
resource "baremetal_core_instance" "docker-cluster" {
    count = "${var.instance_count}"

    availability_domain = "${lookup(data.baremetal_identity_availability_domains.ADs.availability_domains[var.AD - 1],"name")}" 
    compartment_id = "${var.compartment_ocid}"
    display_name = "${var.instance_prefix}-manager-${count.index}"
    image = "${lookup(data.baremetal_core_images.OLImageOCID.images[0], "id")}"
    shape = "${var.InstanceShape}"
    subnet_id = "${var.SubnetOCID}"
    metadata {
        ssh_authorized_keys = "${var.ssh_public_key}"
        user_data = "${base64encode(file(var.BootStrapFile))}"
    }

    connection {
        agent = false
        timeout = "10m"
        host = "${self.private_ip}"
        user = "opc"
        private_key = "${file(var.ssh_private_key)}"
        bastion_user = "${var.ssh_bastion_user}"
        bastion_host = "${var.ssh_bastion_host}"
        bastion_private_key = "${file("${var.ssh_bastion_private_key}")}"
    }

    provisioner "file" "setup-docker" {
        source = "files/setup-docker-oracle-linux.sh"
        destination = "/home/opc/setup-docker-oracle-linux.sh"
    }

    provisioner "remote-exec" {
        inline = [
       "chmod +x /home/opc/setup-docker-oracle-linux.sh",
        "/home/opc/setup-docker-oracle-linux.sh",
        ]
    }
}
```

or

```
resource "null_resource" "cluster_setup" {
    count = "${var.instance_count}"
    #depends_on = ["baremetal_core_instance.Instance"]
    triggers {
        cluster_instance_ids = "${join(",", baremetal_core_instance.cluster.*.private_ip)}"
    }

    provisioner "remote-exec" {
      connection {
        agent = false
        timeout = "10m"
        host = "${element(baremetal_core_instance.cluster.*.private_ip, count.index)}"
        user = "opc"
        private_key = "${file(var.ssh_private_key)}"
        bastion_user = "${var.ssh_bastion_user}"
        bastion_host = "${var.ssh_bastion_host}"
        bastion_private_key = "${file("${var.ssh_bastion_private_key}")}"
    }
      inline = [
        "echo '${join(",", baremetal_core_instance.cluster.*.private_ip)}' > /tmp/important-cluster-config",
      ]
    }
}
```