### PR TITLE
Refine single instance simple example and volume_attachment.md document

### DIFF
--- a/docs/examples/compute/single-instance/block.tf
+++ b/docs/examples/compute/single-instance/block.tf
@@ -2,7 +2,7 @@ resource "baremetal_core_volume" "TFBlock0" {
   availability_domain = "${lookup(data.baremetal_identity_availability_domains.ADs.availability_domains[var.AD - 1],"name")}" 
   compartment_id = "${var.compartment_ocid}"
   display_name = "TFBlock0"
-  size_in_mbs = "${var.2TB}"
+  size_in_mbs = "${var.256GB}"
 }
 
 resource "baremetal_core_volume_attachment" "TFBlock0Attach" {

--- a/docs/examples/compute/single-instance/remote-exec.tf
+++ b/docs/examples/compute/single-instance/remote-exec.tf
@@ -1,15 +1,18 @@
 resource "null_resource" "remote-exec" {
-    depends_on = ["baremetal_core_instance.TFInstance"]
+    depends_on = ["baremetal_core_instance.TFInstance","baremetal_core_volume_attachment.TFBlock0Attach"]
     provisioner "remote-exec" {
       connection {
         agent = false
-        timeout = "10m"
+        timeout = "30m"
         host = "${data.baremetal_core_vnic.InstanceVnic.public_ip_address}"
         user = "opc"
         private_key = "${var.ssh_private_key}"
     }
       inline = [
         "touch ~/IMadeAFile.Right.Here",
+        "sudo iscsiadm -m node -o new -T ${baremetal_core_volume_attachment.TFBlock0Attach.iqn} -p ${baremetal_core_volume_attachment.TFBlock0Attach.ipv4}:${baremetal_core_volume_attachment.TFBlock0Attach.port}",
+        "sudo iscsiadm -m node -o update -T ${baremetal_core_volume_attachment.TFBlock0Attach.iqn} -n node.startup -v automatic",
+        "echo sudo iscsiadm -m node -T ${baremetal_core_volume_attachment.TFBlock0Attach.iqn} -p ${baremetal_core_volume_attachment.TFBlock0Attach.ipv4}:${baremetal_core_volume_attachment.TFBlock0Attach.port} -l >> ~/.bashrc"
       ]
     }
 }

--- a/docs/resources/core/volume_attachment.md
+++ b/docs/resources/core/volume_attachment.md
@@ -36,4 +36,5 @@ The following arguments are supported:
 * `chap_username` - The volume's system-generated Challenge-Handshake-Authentication-Protocol (CHAP) user name.
 * `chap_secret` - The Challenge-Handshake-Authentication-Protocol (CHAP) secret valid for the associated CHAP user name. (Also called the "CHAP password".)
 * `ipv4` - The volume's iSCSI IP address.
+* `port` - The volume's iSCSI port.
 * `iqn` - The target volume's iSCSI Qualified Name in the format defined by RFC 3720.


### PR DESCRIPTION
1. Add missing PORT attribute description to docs/resources/core/volume_attachment.md, 
2. For single instance example, replaced 2TB with 256GB to save money and quota. 2TB new block size makes quota exceeded exception happen easily for testing account.  
3. Refine remove-exec.tf for single instance example to make attached volume visible at OS level automatically by adding iscsiadm commands.