### PR TITLE
Emit plugin version number to debug output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,13 @@ test_acceptance:
 build: test
 	go build -o terraform-provider-baremetal
 
-cross: test_acceptance
+version:
+	sed -i '' -e 's/version = ".*"/version = "\
+	$(shell curl -s https://api.github.com/repos/oracle/terraform-provider-baremetal/releases/latest | \
+	jq -r '.tag_name')\
+	"/g' version.go
+
+release: version test_acceptance
 	gox -output "./bin/{{.OS}}_{{.Arch}}/terraform-provider-baremetal"
 
 zip:
@@ -32,4 +38,4 @@ zip:
 	&& tar -czvf linux.tar.gz linux_386 linux_amd64 linux_arm \
 	&& tar -czvf openbsd.tar.gz openbsd_386 openbsd_amd64
 
-.PHONY: clean fmt build cross test test_unit zip
+.PHONY: clean fmt build release test test_unit zip version

--- a/main.go
+++ b/main.go
@@ -8,6 +8,8 @@ import (
 )
 
 func main() {
+	printVersion()
+
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: func() terraform.ResourceProvider {
 			return Provider(providerConfig)

--- a/version.go
+++ b/version.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"log"
+	"strconv"
+	"strings"
+)
+
+// Current public release available on github, overwritten as build step, do not alter, see Makefile
+const version = "v0.0.0"
+
+func printVersion() {
+	// increment build number programatically since this will be the next public release
+	strs := strings.Split(version, ".")
+	build, _ := strconv.ParseInt(strs[2], 10, 64)
+	strs[2] = strconv.FormatInt(build+1, 10)
+	log.Printf("[INFO] terraform-provider-baremetal %s\n", strings.Join(strs, "."))
+}


### PR DESCRIPTION
* printed in all verbose terraform execution `TF_LOG=DEBUG terraform apply`
* printed when running `terraform-provider-baremetal` plugin directly