### PR TITLE
bastion_key should be bastion_private_key

### DIFF
--- a/docs/examples/DBsystems/remote-exec.tf
+++ b/docs/examples/DBsystems/remote-exec.tf
@@ -10,7 +10,7 @@ resource "null_resource" "remote-exec" {
         # Bastion details
         bastion_host = "${var.BastionHost}"
         bastion_user = "${var.HostUserName}"
-        bastion_key = "${var.ssh_private_key}"        
+        bastion_private_key = "${var.ssh_private_key}"        
     }
       source = "./scripts/bootstrap"
       destination = "~/bootstrap.sh"
@@ -27,7 +27,7 @@ resource "null_resource" "remote-exec" {
         # Bastion details
         bastion_host = "${var.BastionHost}"       
         bastion_user = "${var.HostUserName}"
-        bastion_key = "${var.ssh_private_key}"
+        bastion_private_key = "${var.ssh_private_key}"
     }
       inline = [
         "chmod +x ~/bootstrap.sh",


### PR DESCRIPTION
bastion_key should be bastion_private_key.

Without the change fails with:
1 error(s) occurred:

* null_resource.remote-exec: unknown 'connection' argument "bastion_key"
