### PR TITLE
Add TravisCI build file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+
+matrix:
+  include:
+    - go: 1.7
+    - go: 1.8
+    - go: tip
+  allow_failures:
+    - go: tip
+
+go_import_path: github.com/oracle/terraform-provider-baremetal
+
+script:
+  - go test -v -race $(go list ./... | grep -v '/vendor/')


### PR DESCRIPTION
Signed-off-by: Gábor Lipták <gliptak@gmail.com>

https://github.com/oracle/terraform-provider-baremetal/issues/166
https://github.com/oracle/terraform-provider-baremetal/issues/171

https://travis-ci.org/gliptak/terraform-provider-baremetal/jobs/254643997

```
client/mocks/bare_metal_client.go:3709: cannot use (*BareMetalClient)(nil) (type *BareMetalClient) as type client.BareMetalClient in assignment:

	*BareMetalClient does not implement client.BareMetalClient (wrong type for CreateLoadBalancer method)

		have CreateLoadBalancer(*baremetal.BackendSet, *baremetal.Certificate, string, *baremetal.Listener, string, []string, *baremetal.CreateOptions) (string, error)

		want CreateLoadBalancer(*baremetal.BackendSet, *baremetal.Certificate, string, *baremetal.Listener, string, []string, *baremetal.CreateLoadBalancerOptions) (string, error)
```