### PR TITLE
Add Wercker CI/CD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ terraform-encrypted-des.sh
 terraform-encrypted.sh
 terraform-plain.sh
 .DS_Store
+
+.wercker

--- a/client/mocks/bare_metal_client.go
+++ b/client/mocks/bare_metal_client.go
@@ -393,18 +393,18 @@ func (_m *BareMetalClient) CreateListener(loadBalancerID string, name string, de
 }
 
 // CreateLoadBalancer provides a mock function with given fields: backendSets, certificates, compartmentID, listeners, shape, subnetIDs, opts
-func (_m *BareMetalClient) CreateLoadBalancer(backendSets *baremetal.BackendSet, certificates *baremetal.Certificate, compartmentID string, listeners *baremetal.Listener, shape string, subnetIDs []string, opts *baremetal.CreateOptions) (string, error) {
+func (_m *BareMetalClient) CreateLoadBalancer(backendSets *baremetal.BackendSet, certificates *baremetal.Certificate, compartmentID string, listeners *baremetal.Listener, shape string, subnetIDs []string, opts *baremetal.CreateLoadBalancerOptions) (string, error) {
 	ret := _m.Called(backendSets, certificates, compartmentID, listeners, shape, subnetIDs, opts)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func(*baremetal.BackendSet, *baremetal.Certificate, string, *baremetal.Listener, string, []string, *baremetal.CreateOptions) string); ok {
+	if rf, ok := ret.Get(0).(func(*baremetal.BackendSet, *baremetal.Certificate, string, *baremetal.Listener, string, []string, *baremetal.CreateLoadBalancerOptions) string); ok {
 		r0 = rf(backendSets, certificates, compartmentID, listeners, shape, subnetIDs, opts)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*baremetal.BackendSet, *baremetal.Certificate, string, *baremetal.Listener, string, []string, *baremetal.CreateOptions) error); ok {
+	if rf, ok := ret.Get(1).(func(*baremetal.BackendSet, *baremetal.Certificate, string, *baremetal.Listener, string, []string, *baremetal.CreateLoadBalancerOptions) error); ok {
 		r1 = rf(backendSets, certificates, compartmentID, listeners, shape, subnetIDs, opts)
 	} else {
 		r1 = ret.Error(1)
@@ -3386,18 +3386,18 @@ func (_m *BareMetalClient) UpdateListener(loadBalancerID string, listenerName st
 }
 
 // UpdateLoadBalancer provides a mock function with given fields: id, opts
-func (_m *BareMetalClient) UpdateLoadBalancer(id string, opts *baremetal.UpdateOptions) (string, error) {
+func (_m *BareMetalClient) UpdateLoadBalancer(id string, opts *baremetal.UpdateLoadBalancerOptions) (string, error) {
 	ret := _m.Called(id, opts)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func(string, *baremetal.UpdateOptions) string); ok {
+	if rf, ok := ret.Get(0).(func(string, *baremetal.UpdateLoadBalancerOptions) string); ok {
 		r0 = rf(id, opts)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, *baremetal.UpdateOptions) error); ok {
+	if rf, ok := ret.Get(1).(func(string, *baremetal.UpdateLoadBalancerOptions) error); ok {
 		r1 = rf(id, opts)
 	} else {
 		r1 = ret.Error(1)

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,16 @@
+box: golang:1.8
+build:
+  base-path: /go/src/github.com/oracle/terraform-provider-baremetal
+  steps:
+    - script:
+        name: install govendor
+        code: go get -u github.com/kardianos/govendor
+    #- script:
+    #    name: go vet
+    #    code: govendor vet +local
+    - script:
+        name: go build
+        code: govendor build +local
+    #- script:
+    #    name: go test
+    #    code: govendor test +local


### PR DESCRIPTION
This adds Wercker.com CI/CD: https://app.wercker.com/tjfontaine/terraform-provider-baremetal/runs

Currently `go vet` is disabled because of unreachable code: https://github.com/oracle/terraform-provider-baremetal/blob/v1.0.16/resource_obmcs_identity_compartment.go#L59-L60

`go test` is also disabled because they require credentials (which can be enabled in Wercker) but I didn't have access to them.