### PR TITLE
DHCP options example, doc and test update

### DIFF
--- a/crud/helpers.go
+++ b/crud/helpers.go
@@ -17,11 +17,11 @@ import (
 )
 
 var (
-	FiveMinutes    time.Duration = 5 * time.Minute
-	TwoHours       time.Duration = 120 * time.Minute
-	ZeroTime       time.Duration = 0
+	FiveMinutes time.Duration = 5 * time.Minute
+	TwoHours    time.Duration = 120 * time.Minute
+	ZeroTime    time.Duration = 0
 
-	DefaultTimeout               = &schema.ResourceTimeout{
+	DefaultTimeout = &schema.ResourceTimeout{
 		Create: &FiveMinutes,
 		Update: &FiveMinutes,
 		Delete: &FiveMinutes,
@@ -185,7 +185,7 @@ func CreateDBSystemResource(d *schema.ResourceData, sync ResourceCreator) (e err
 	shape := d.Get("shape")
 	timeout = d.Timeout(schema.TimeoutCreate)
 	if timeout == 0 {
-		if strings.HasPrefix(shape.(string), "Exadata"){
+		if strings.HasPrefix(shape.(string), "Exadata") {
 			timeout = time.Duration(12) * time.Hour
 		} else {
 			timeout = time.Duration(2) * time.Hour

--- a/data_source_obmcs_database_db_version.go
+++ b/data_source_obmcs_database_db_version.go
@@ -30,8 +30,8 @@ func DBVersionDatasource() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"supports_pdb":{
-							Type: schema.TypeBool,
+						"supports_pdb": {
+							Type:     schema.TypeBool,
 							Computed: true,
 						},
 					},
@@ -95,7 +95,7 @@ func (s *DBVersionDatasourceCrud) SetData() {
 		resources := []map[string]interface{}{}
 		for _, v := range s.Res.DBVersions {
 			res := map[string]interface{}{
-				"version": v.Version,
+				"version":      v.Version,
 				"supports_pdb": v.SupportsPDB,
 			}
 			resources = append(resources, res)

--- a/docs/examples/networking/dhcp_options/dhcp_options.tf
+++ b/docs/examples/networking/dhcp_options/dhcp_options.tf
@@ -1,0 +1,60 @@
+/*
+ * This example demonstrates the various dhcp option configurations.
+ */
+
+variable "tenancy_ocid" {}
+variable "user_ocid" {}
+variable "fingerprint" {}
+variable "private_key_path" {}
+variable "compartment_ocid" {}
+variable "region" {}
+
+variable "vcn_ocid" {}
+
+
+provider "baremetal" {
+  tenancy_ocid = "${var.tenancy_ocid}"
+  user_ocid = "${var.user_ocid}"
+  fingerprint = "${var.fingerprint}"
+  private_key_path = "${var.private_key_path}"
+  region = "${var.region}"
+}
+
+
+resource "baremetal_core_dhcp_options" "dhcp-options1" {
+  compartment_id = "${var.compartment_ocid}"
+  vcn_id = "${var.vcn_ocid}"
+  display_name = "dhcp-options1"
+
+  // required
+  options {
+    type = "DomainNameServer"
+    server_type = "VcnLocalPlusInternet"
+  }
+
+  // optional
+  options {
+    type = "SearchDomain"
+    search_domain_names = [ "test.com" ]
+  }
+}
+
+
+resource "baremetal_core_dhcp_options" "dhcp-options2" {
+  compartment_id = "${var.compartment_ocid}"
+  vcn_id = "${var.vcn_ocid}"
+  display_name = "dhcp-options2"
+
+  // required
+  options {
+    type = "DomainNameServer"
+    server_type = "CustomDnsServer"
+    custom_dns_servers = [  "8.8.4.4", "8.8.8.8" ]
+  }
+
+  // optional
+  options {
+    type = "SearchDomain"
+    search_domain_names = [ "test.com" ]
+  }
+}

--- a/docs/resources/core/dhcp_option.md
+++ b/docs/resources/core/dhcp_option.md
@@ -2,23 +2,52 @@
 
 Provide a Dhcp Options resource.
 
+For more information, see 
+[DNS in Your Virtual Cloud Network](https://docs.us-phoenix-1.oraclecloud.com/Content/Network/Concepts/dns.htm)
+
 ## Example Usage
 
+#### VCN Local with Internet 
 ```
-resource "baremetal_core_dhcp_options" "t" {
-    compartment_id = "compartment_id"
-    display_name = "display_name"
-    options {
-        type = "type"
-        custom_dns_servers = [ "custom_dns_servers" ]
-        server_type = "server_type"
-    }
-    options {
-        type = "type"
-        custom_dns_servers = [ "custom_dns_servers" ]
-        server_type = "server_type"
-    }
-    vcn_id = "vcn_id"
+resource "baremetal_core_dhcp_options" "dhcp-options1" {
+  compartment_id = "${var.compartment_ocid}"
+  vcn_id = "${var.vcn_ocid}"
+  display_name = "dhcp-options1"
+  
+  // required
+  options {
+    type = "DomainNameServer"
+    server_type = "VcnLocalPlusInternet"
+  }
+  
+  // optional
+  options {
+    type = "SearchDomain"
+    search_domain_names = [ "test.com" ]
+  }
+}
+```
+
+#### Custom DNS Server
+
+```
+resource "baremetal_core_dhcp_options" "dhcp-options2" {
+  compartment_id = "${var.compartment_ocid}"
+  vcn_id = "${var.vcn_ocid}"
+  display_name = "dhcp-options3"
+  
+  // required
+  options {
+    type = "DomainNameServer"
+    server_type = "CustomDnsServer"
+    custom_dns_servers = [ "192.168.0.2", "192.168.0.11", "192.168.0.19" ]
+  }
+  
+  // optional
+  options {
+    type = "SearchDomain"
+    search_domain_names = [ "test.com" ]
+  }
 }
 ```
 
@@ -29,7 +58,7 @@ The following arguments are supported:
 * `compartment_id` - (Required) The OCID of the compartment.
 * `vcn_id` - (Required) The OCID of the VCN.
 * `display_name` - (Optional) A user-friendly name. Does not have to be unique, and it's changeable.
-* `options` - (Required) A set of DHCP options.
+* `options` - (Required) A set of [DHCP Options](https://docs.us-phoenix-1.oraclecloud.com/api/#/en/iaas/20160918/DhcpDnsOption/).
 
 ## Attributes Reference
 * `compartment_id` - The OCID of the compartment containing the set of DHCP options.

--- a/helpers_objectstorage.go
+++ b/helpers_objectstorage.go
@@ -110,7 +110,7 @@ var preauthenticatedRequestSchema = map[string]*schema.Schema{
 			string(baremetal.ObjectRead)}, true),
 	},
 	"access_uri": {
-		Type: schema.TypeString,
+		Type:     schema.TypeString,
 		Computed: true,
 		Optional: true,
 	},

--- a/provider_test.go
+++ b/provider_test.go
@@ -294,6 +294,7 @@ func GetTestProvider() mockableClient {
 		d.Set("private_key_path", getRequiredEnvSetting("private_key_path"))
 		d.Set("private_key_password", getEnvSetting("private_key_password", ""))
 		d.Set("private_key", getEnvSetting("private_key", ""))
+		d.Set("disable_auto_retries", true)
 
 		client, err := providerConfig(d)
 		if err != nil {

--- a/resource_obmcs_core_dhcp_options_test.go
+++ b/resource_obmcs_core_dhcp_options_test.go
@@ -47,20 +47,58 @@ func (s *ResourceCoreDHCPOptionsTestSuite) SetupTest() {
 		compartment_id = "${var.compartment_id}"
 		display_name = "network_name"
 	}
-	resource "baremetal_core_dhcp_options" "t" {
-		compartment_id = "${var.compartment_id}"
-		display_name = "display_name"
-     		options {
-			type = "DomainNameServer"
-			custom_dns_servers = [ "8.8.8.8" ]
-			server_type = "CustomDnsServer"
-		}
-     		vcn_id = "${baremetal_core_virtual_network.t.id}"
+
+	resource "baremetal_core_dhcp_options" "opt1" {
+	  compartment_id = "${var.compartment_id}"
+	  vcn_id = "${baremetal_core_virtual_network.t.id}"
+	  display_name = "display_name"
+	  options {
+	    type = "DomainNameServer"
+	    server_type = "VcnLocalPlusInternet"
+	  }
+	}
+
+	resource "baremetal_core_dhcp_options" "opt2" {
+	  compartment_id = "${var.compartment_id}"
+	  vcn_id = "${baremetal_core_virtual_network.t.id}"
+	  display_name = "display_name"
+	  options {
+	    type = "DomainNameServer"
+	    server_type = "VcnLocalPlusInternet"
+	  }
+	  options {
+	    type = "SearchDomain"
+	    search_domain_names = [ "test.com" ]
+	  }
+	}
+
+	resource "baremetal_core_dhcp_options" "opt3" {
+	  compartment_id = "${var.compartment_id}"
+	  vcn_id = "${baremetal_core_virtual_network.t.id}"
+	  display_name = "display_name"
+	  options {
+	    type = "DomainNameServer"
+	    server_type = "CustomDnsServer"
+	    custom_dns_servers = [  "8.8.4.4", "8.8.8.8" ]
+	  }
+	}
+
+	resource "baremetal_core_dhcp_options" "opt4" {
+	  compartment_id = "${var.compartment_id}"
+	  vcn_id = "${baremetal_core_virtual_network.t.id}"
+	  display_name = "display_name"
+	  options {
+	    type = "DomainNameServer"
+	    server_type = "CustomDnsServer"
+	    custom_dns_servers = [  "8.8.4.4", "8.8.8.8" ]
+	  }
+	  options {
+	    type = "SearchDomain"
+	    search_domain_names = [ "test.com" ]
+	  }
 	}
 	`
 	s.Config += testProviderConfig()
-
-	s.ResourceName = "baremetal_core_dhcp_options.t"
 }
 
 func (s *ResourceCoreDHCPOptionsTestSuite) TestCreateResourceCoreDHCPOptions() {
@@ -74,9 +112,21 @@ func (s *ResourceCoreDHCPOptionsTestSuite) TestCreateResourceCoreDHCPOptions() {
 				Config:            s.Config,
 				Check: resource.ComposeTestCheckFunc(
 
-					resource.TestCheckResourceAttr(s.ResourceName, "display_name", "display_name"),
-					resource.TestCheckResourceAttr(s.ResourceName, "options.0.type", "DomainNameServer"),
-					resource.TestCheckResourceAttr(s.ResourceName, "options.0.server_type", "CustomDnsServer"),
+					resource.TestCheckResourceAttr("baremetal_core_dhcp_options.opt1", "display_name", "display_name"),
+
+					resource.TestCheckResourceAttr("baremetal_core_dhcp_options.opt1", "options.0.type", "DomainNameServer"),
+					resource.TestCheckResourceAttr("baremetal_core_dhcp_options.opt1", "options.0.server_type", "VcnLocalPlusInternet"),
+
+					resource.TestCheckResourceAttr("baremetal_core_dhcp_options.opt2", "options.0.type", "DomainNameServer"),
+					resource.TestCheckResourceAttr("baremetal_core_dhcp_options.opt2", "options.0.server_type", "VcnLocalPlusInternet"),
+					resource.TestCheckResourceAttr("baremetal_core_dhcp_options.opt2", "options.1.type", "SearchDomain"),
+
+					resource.TestCheckResourceAttr("baremetal_core_dhcp_options.opt3", "options.0.type", "DomainNameServer"),
+					resource.TestCheckResourceAttr("baremetal_core_dhcp_options.opt3", "options.0.server_type", "CustomDnsServer"),
+
+					resource.TestCheckResourceAttr("baremetal_core_dhcp_options.opt4", "options.0.type", "DomainNameServer"),
+					resource.TestCheckResourceAttr("baremetal_core_dhcp_options.opt4", "options.0.server_type", "CustomDnsServer"),
+					resource.TestCheckResourceAttr("baremetal_core_dhcp_options.opt4", "options.1.type", "SearchDomain"),
 				),
 			},
 		},

--- a/resource_obmcs_core_instance.go
+++ b/resource_obmcs_core_instance.go
@@ -5,12 +5,12 @@ package main
 import (
 	"log"
 
+	"encoding/json"
 	"github.com/MustWin/baremetal-sdk-go"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/oracle/terraform-provider-baremetal/client"
 	"github.com/oracle/terraform-provider-baremetal/crud"
 	"github.com/oracle/terraform-provider-baremetal/options"
-	"encoding/json"
 )
 
 func InstanceResource() *schema.Resource {


### PR DESCRIPTION
* also removes retry for running acceptance tests

TESTS
* run the `dhcp_options.tf` example
* execute acceptance tests
  * `TF_ACC=1 TF_ORACLE_ENV=test ./terraform-plain.sh -timeout 120m -run TestResourceCoreDHCPOptionsTestSuite`