### PR TITLE
Identity test fixes and improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,15 @@ clean:
 fmt:
 	gofmt -w $(GOFMT_FILES)
 
+show_tests:
+	grep -ohi "Test.*$(test).*TestSuite" *.go
+
+run_one:
+	TF_ORACLE_ENV=test TF_ACC=1 go test -v -run $(test)
+
+run_one_debug:
+	TF_LOG=DEBUG DEBUG=true TF_ORACLE_ENV=test TF_ACC=1 go test -v -run $(test)
+
 test_acceptance_debug:
 	TF_LOG=DEBUG DEBUG=true TF_ORACLE_ENV=test TF_ACC=1 go test -v -timeout 120m
 

--- a/data_source_obmcs_core_drg_test.go
+++ b/data_source_obmcs_core_drg_test.go
@@ -68,6 +68,6 @@ func (s *ResourceCoreDrgsTestSuite) TestReadDrgs() {
 
 }
 
-func TestResourceCoreDrgsTestSuite(t *testing.T) {
+func TestDatasourceCoreDrgsTestSuite(t *testing.T) {
 	suite.Run(t, new(ResourceCoreDrgsTestSuite))
 }

--- a/data_source_obmcs_core_security_list_test.go
+++ b/data_source_obmcs_core_security_list_test.go
@@ -93,6 +93,6 @@ func (s *CoreSecurityListDatasourceTestSuite) TestReadSecurityLists() {
 	)
 }
 
-func TestCoreSecurityListDatasourceTestSuite(t *testing.T) {
+func TestDatasourceCoreSecurityListTestSuite(t *testing.T) {
 	suite.Run(t, new(CoreSecurityListDatasourceTestSuite))
 }

--- a/data_source_obmcs_identity_api_key_test.go
+++ b/data_source_obmcs_identity_api_key_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type ResourceIdentityAPIKeysTestSuite struct {
+type DatasourceIdentityAPIKeysTestSuite struct {
 	suite.Suite
 	Client       mockableClient
 	Config       string
@@ -24,7 +24,7 @@ type ResourceIdentityAPIKeysTestSuite struct {
 	List         *baremetal.ListAPIKeyResponses
 }
 
-func (s *ResourceIdentityAPIKeysTestSuite) SetupTest() {
+func (s *DatasourceIdentityAPIKeysTestSuite) SetupTest() {
 	s.Client = GetTestProvider()
 	s.Provider = Provider(func(d *schema.ResourceData) (interface{}, error) {
 		return s.Client, nil
@@ -35,8 +35,8 @@ func (s *ResourceIdentityAPIKeysTestSuite) SetupTest() {
 	}
 	s.Config = `
 	resource "baremetal_identity_user" "t" {
-			name = "name1"
-			description = "desc!"
+			name = "-tf-test"
+			description = "automated test user"
 		}
 		resource "baremetal_identity_api_key" "t" {
 			user_id = "${baremetal_identity_user.t.id}"
@@ -74,7 +74,7 @@ EOF
 	}
 }
 
-func (s *ResourceIdentityAPIKeysTestSuite) TestReadAPIKeys() {
+func (s *DatasourceIdentityAPIKeysTestSuite) TestReadAPIKeys() {
 
 	resource.UnitTest(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
@@ -98,9 +98,8 @@ func (s *ResourceIdentityAPIKeysTestSuite) TestReadAPIKeys() {
 		},
 	},
 	)
-
 }
 
-func TestResourceIdentityAPIKeysTestSuite(t *testing.T) {
-	suite.Run(t, new(ResourceIdentityAPIKeysTestSuite))
+func TestDatasourceIdentityAPIKeysTestSuite(t *testing.T) {
+	suite.Run(t, new(DatasourceIdentityAPIKeysTestSuite))
 }

--- a/data_source_obmcs_identity_availability_domain_test.go
+++ b/data_source_obmcs_identity_availability_domain_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type ResourceIdentityAvailabilityDomainsTestSuite struct {
+type DatasourceIdentityAvailabilityDomainsTestSuite struct {
 	suite.Suite
 	Client       mockableClient
 	Config       string
@@ -22,7 +22,7 @@ type ResourceIdentityAvailabilityDomainsTestSuite struct {
 	List         *baremetal.ListAvailabilityDomains
 }
 
-func (s *ResourceIdentityAvailabilityDomainsTestSuite) SetupTest() {
+func (s *DatasourceIdentityAvailabilityDomainsTestSuite) SetupTest() {
 	s.Client = GetTestProvider()
 	s.Provider = Provider(func(d *schema.ResourceData) (interface{}, error) {
 		return s.Client, nil
@@ -32,10 +32,10 @@ func (s *ResourceIdentityAvailabilityDomainsTestSuite) SetupTest() {
 		"baremetal": s.Provider,
 	}
 	s.Config = `
-    data "baremetal_identity_availability_domains" "t" {
-      compartment_id = "${var.compartment_id}"
-    }
-  `
+	data "baremetal_identity_availability_domains" "t" {
+	  compartment_id = "${var.compartment_id}"
+	}
+`
 	s.Config += testProviderConfig()
 	s.ResourceName = "data.baremetal_identity_availability_domains.t"
 
@@ -52,7 +52,7 @@ func (s *ResourceIdentityAvailabilityDomainsTestSuite) SetupTest() {
 	}
 }
 
-func (s *ResourceIdentityAvailabilityDomainsTestSuite) TestReadAvailabilityDomains() {
+func (s *DatasourceIdentityAvailabilityDomainsTestSuite) TestReadAvailabilityDomains() {
 
 	resource.UnitTest(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
@@ -73,6 +73,6 @@ func (s *ResourceIdentityAvailabilityDomainsTestSuite) TestReadAvailabilityDomai
 
 }
 
-func TestResourceIdentityAvailabilityDomainsTestSuite(t *testing.T) {
-	suite.Run(t, new(ResourceIdentityAvailabilityDomainsTestSuite))
+func TestDatasourceIdentityAvailabilityDomainsTestSuite(t *testing.T) {
+	suite.Run(t, new(DatasourceIdentityAvailabilityDomainsTestSuite))
 }

--- a/data_source_obmcs_identity_compartment_test.go
+++ b/data_source_obmcs_identity_compartment_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type ResourceIdentityCompartmentsTestSuite struct {
+type DatasourceIdentityCompartmentsTestSuite struct {
 	suite.Suite
 	Client       mockableClient
 	Config       string
@@ -24,7 +24,7 @@ type ResourceIdentityCompartmentsTestSuite struct {
 	List         *baremetal.ListCompartments
 }
 
-func (s *ResourceIdentityCompartmentsTestSuite) SetupTest() {
+func (s *DatasourceIdentityCompartmentsTestSuite) SetupTest() {
 	s.Client = GetTestProvider()
 	s.Provider = Provider(func(d *schema.ResourceData) (interface{}, error) {
 		return s.Client, nil
@@ -58,7 +58,7 @@ func (s *ResourceIdentityCompartmentsTestSuite) SetupTest() {
 	}
 }
 
-func (s *ResourceIdentityCompartmentsTestSuite) TestReadCompartments() {
+func (s *DatasourceIdentityCompartmentsTestSuite) TestReadCompartments() {
 
 	resource.UnitTest(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
@@ -78,6 +78,6 @@ func (s *ResourceIdentityCompartmentsTestSuite) TestReadCompartments() {
 	)
 }
 
-func TestResourceIdentityCompartmentsTestSuite(t *testing.T) {
-	suite.Run(t, new(ResourceIdentityCompartmentsTestSuite))
+func TestDatasourceIdentityCompartmentsTestSuite(t *testing.T) {
+	suite.Run(t, new(DatasourceIdentityCompartmentsTestSuite))
 }

--- a/data_source_obmcs_identity_group_test.go
+++ b/data_source_obmcs_identity_group_test.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"testing"
-	"time"
 
 	"github.com/MustWin/baremetal-sdk-go"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -14,7 +13,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type ResourceIdentityGroupsTestSuite struct {
+type DatasourceIdentityGroupsTestSuite struct {
 	suite.Suite
 	Client       mockableClient
 	Config       string
@@ -24,7 +23,7 @@ type ResourceIdentityGroupsTestSuite struct {
 	List         *baremetal.ListGroups
 }
 
-func (s *ResourceIdentityGroupsTestSuite) SetupTest() {
+func (s *DatasourceIdentityGroupsTestSuite) SetupTest() {
 	s.Client = GetTestProvider()
 	s.Provider = Provider(func(d *schema.ResourceData) (interface{}, error) {
 		return s.Client, nil
@@ -35,31 +34,15 @@ func (s *ResourceIdentityGroupsTestSuite) SetupTest() {
 	}
 	s.Config = `
 	resource "baremetal_identity_group" "t" {
-		name = "groupname"
-		description = "group desc!"
+		name = "-tf-group"
+		description = "automated test group"
 	}
   `
 	s.Config += testProviderConfig()
 	s.ResourceName = "data.baremetal_identity_groups.t"
-
-	b1 := baremetal.Group{
-		ID:            "id",
-		Name:          "groupname",
-		CompartmentID: "compartment",
-		Description:   "blah",
-		State:         baremetal.ResourceActive,
-		TimeCreated:   time.Now(),
-	}
-
-	b2 := b1
-	b2.ID = "id2"
-
-	s.List = &baremetal.ListGroups{
-		Groups: []baremetal.Group{b1, b2},
-	}
 }
 
-func (s *ResourceIdentityGroupsTestSuite) TestReadGroups() {
+func (s *DatasourceIdentityGroupsTestSuite) TestReadGroups() {
 
 	resource.UnitTest(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
@@ -85,6 +68,6 @@ func (s *ResourceIdentityGroupsTestSuite) TestReadGroups() {
 	)
 }
 
-func TestResourceIdentityGroupsTestSuite(t *testing.T) {
-	suite.Run(t, new(ResourceIdentityGroupsTestSuite))
+func TestDatasourceIdentityGroupsTestSuite(t *testing.T) {
+	suite.Run(t, new(DatasourceIdentityGroupsTestSuite))
 }

--- a/data_source_obmcs_identity_swift_password_test.go
+++ b/data_source_obmcs_identity_swift_password_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/MustWin/baremetal-sdk-go"
 )
 
-type ResourceIdentitySwiftPasswordsTestSuite struct {
+type DatasourceIdentitySwiftPasswordsTestSuite struct {
 	suite.Suite
 	Client        mockableClient
 	Provider      terraform.ResourceProvider
@@ -25,7 +25,7 @@ type ResourceIdentitySwiftPasswordsTestSuite struct {
 	PasswordList  baremetal.ListSwiftPasswords
 }
 
-func (s *ResourceIdentitySwiftPasswordsTestSuite) SetupTest() {
+func (s *DatasourceIdentitySwiftPasswordsTestSuite) SetupTest() {
 	s.Client = GetTestProvider()
 	s.Provider = Provider(func(d *schema.ResourceData) (interface{}, error) {
 		return s.Client, nil
@@ -50,7 +50,7 @@ func (s *ResourceIdentitySwiftPasswordsTestSuite) SetupTest() {
 
 }
 
-func (s *ResourceIdentitySwiftPasswordsTestSuite) TestListResourceIdentitySwiftPasswords() {
+func (s *DatasourceIdentitySwiftPasswordsTestSuite) TestListResourceIdentitySwiftPasswords() {
 	resource.UnitTest(s.T(), resource.TestCase{
 		Providers: s.Providers,
 		Steps: []resource.TestStep{
@@ -74,6 +74,6 @@ func (s *ResourceIdentitySwiftPasswordsTestSuite) TestListResourceIdentitySwiftP
 	)
 }
 
-func TestResourceIdentitySwiftPasswordsTestSuite(t *testing.T) {
-	suite.Run(t, new(ResourceIdentitySwiftPasswordsTestSuite))
+func TestDatasourceIdentitySwiftPasswordsTestSuite(t *testing.T) {
+	suite.Run(t, new(DatasourceIdentitySwiftPasswordsTestSuite))
 }

--- a/data_source_obmcs_identity_user_group_membership_test.go
+++ b/data_source_obmcs_identity_user_group_membership_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/MustWin/baremetal-sdk-go"
 )
 
-type ResourceIdentityUserGroupMembershipsTestSuite struct {
+type DatasourceIdentityUserGroupMembershipsTestSuite struct {
 	suite.Suite
 	Client       mockableClient
 	Config       string
@@ -23,7 +23,7 @@ type ResourceIdentityUserGroupMembershipsTestSuite struct {
 	List         *baremetal.ListUserGroupMemberships
 }
 
-func (s *ResourceIdentityUserGroupMembershipsTestSuite) SetupTest() {
+func (s *DatasourceIdentityUserGroupMembershipsTestSuite) SetupTest() {
 	s.Client = GetTestProvider()
 	s.Provider = Provider(func(d *schema.ResourceData) (interface{}, error) {
 		return s.Client, nil
@@ -35,38 +35,40 @@ func (s *ResourceIdentityUserGroupMembershipsTestSuite) SetupTest() {
 
 	s.Config = `
     resource "baremetal_identity_user" "u" {
-	name = "user_name"
-	description = "user desc"
+		name = "user_name"
+		description = "user desc"
     }
     resource "baremetal_identity_group" "g" {
-	name = "group_name"
-	description = "group desc"
+		name = "group_name"
+		description = "group desc"
     }
     resource "baremetal_identity_user_group_membership" "ug_membership" {
     	compartment_id = "${var.tenancy_ocid}"
-	user_id = "${baremetal_identity_user.u.id}"
-	group_id = "${baremetal_identity_group.g.id}"
+		user_id = "${baremetal_identity_user.u.id}"
+		group_id = "${baremetal_identity_group.g.id}"
     }
   `
 	s.Config += testProviderConfig()
 	s.ResourceName = "baremetal_identity_user_group_membership.ug_membership"
 }
 
-func (s *ResourceIdentityUserGroupMembershipsTestSuite) TestGetUserGroupMembershipsByGroup() {
+func (s *DatasourceIdentityUserGroupMembershipsTestSuite) TestGetUserGroupMembershipsByGroup() {
 	config := `
 	data "baremetal_identity_user_group_memberships" "g_memberships" {
 	    compartment_id = "${var.tenancy_ocid}"
 	    group_id = "${baremetal_identity_group.g.id}"
-        }
-        data "baremetal_identity_user_group_memberships" "u_memberships" {
+	}
+
+	data "baremetal_identity_user_group_memberships" "u_memberships" {
 		compartment_id = "${var.tenancy_ocid}"
 		user_id = "${baremetal_identity_user.u.id}"
 	}
+
 	data "baremetal_identity_user_group_memberships" "ug_memberships" {
 	    compartment_id = "${var.tenancy_ocid}"
 	    user_id = "${baremetal_identity_user.u.id}"
 	    group_id = "${baremetal_identity_group.g.id}"
-        }
+	}
 	`
 	resource.UnitTest(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
@@ -93,6 +95,6 @@ func (s *ResourceIdentityUserGroupMembershipsTestSuite) TestGetUserGroupMembersh
 	)
 }
 
-func TestResourceIdentityUserGroupMembershipsTestSuite(t *testing.T) {
-	suite.Run(t, new(ResourceIdentityUserGroupMembershipsTestSuite))
+func TestDatasourceIdentityUserGroupMembershipsTestSuite(t *testing.T) {
+	suite.Run(t, new(DatasourceIdentityUserGroupMembershipsTestSuite))
 }

--- a/data_source_obmcs_identity_user_test.go
+++ b/data_source_obmcs_identity_user_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type ResourceIdentityUsersTestSuite struct {
+type DatasourceIdentityUsersTestSuite struct {
 	suite.Suite
 	Client       mockableClient
 	Config       string
@@ -23,7 +23,7 @@ type ResourceIdentityUsersTestSuite struct {
 	List         *baremetal.ListUsers
 }
 
-func (s *ResourceIdentityUsersTestSuite) SetupTest() {
+func (s *DatasourceIdentityUsersTestSuite) SetupTest() {
 	s.Client = GetTestProvider()
 	s.Provider = Provider(func(d *schema.ResourceData) (interface{}, error) {
 		return s.Client, nil
@@ -34,15 +34,15 @@ func (s *ResourceIdentityUsersTestSuite) SetupTest() {
 	}
 	s.Config = `
 		resource "baremetal_identity_user" "t" {
-			name = "name1"
-			description = "desc!"
+			name = "-tf-user"
+			description = "automated test user"
 		}
 	`
 	s.Config += testProviderConfig()
 	s.ResourceName = "data.baremetal_identity_users.t"
 }
 
-func (s *ResourceIdentityUsersTestSuite) TestReadUsers() {
+func (s *DatasourceIdentityUsersTestSuite) TestReadUsers() {
 
 	resource.UnitTest(s.T(), resource.TestCase{
 		PreventPostDestroyRefresh: true,
@@ -68,6 +68,6 @@ func (s *ResourceIdentityUsersTestSuite) TestReadUsers() {
 	)
 }
 
-func TestResourceIdentityUsersTestSuite(t *testing.T) {
-	suite.Run(t, new(ResourceIdentityUsersTestSuite))
+func TestDatasourceIdentityUsersTestSuite(t *testing.T) {
+	suite.Run(t, new(DatasourceIdentityUsersTestSuite))
 }

--- a/docs/examples/iam/policy/policy.tf
+++ b/docs/examples/iam/policy/policy.tf
@@ -1,3 +1,7 @@
+/*
+ * This example shows how the policy resource and datasource works.
+ */
+
 variable "tenancy_ocid" {}
 variable "user_ocid" {}
 variable "fingerprint" {}
@@ -15,9 +19,27 @@ provider "baremetal" {
   region = "${var.region}"
 }
 
-resource "baremetal_identity_policy" "policy1" {
-  name = "policy1"
-  description = "A terraform managed policy"
-  compartment_id = "${var.compartment_ocid}"
-  statements = ["allow group ${var.group_name} to manage all-resources on tenancy"]
+resource "baremetal_identity_compartment" "t" {
+  name = "test-compartment"
+  description = "automated test compartment"
+}
+
+resource "baremetal_identity_group" "t" {
+  name = "-tf-group"
+  description = "automated test group"
+}
+
+resource "baremetal_identity_policy" "p" {
+  name = "-tf-policy"
+  description = "automated test policy"
+  compartment_id = "${baremetal_identity_compartment.t.id}"
+  statements = ["Allow group ${baremetal_identity_group.t.name} to read instances in compartment ${baremetal_identity_compartment.t.name}"]
+}
+
+data "baremetal_identity_policies" "p" {
+  compartment_id = "${baremetal_identity_compartment.t.id}"
+}
+
+output "policy" {
+  value = ["${data.baremetal_identity_policies.p.policies}"]
 }

--- a/resource_obmcs_identity_api_key_test.go
+++ b/resource_obmcs_identity_api_key_test.go
@@ -36,8 +36,8 @@ func (s *ResourceIdentityAPIKeyTestSuite) SetupTest() {
 
 	s.Config = `
 		resource "baremetal_identity_user" "t" {
-			name = "name1"
-			description = "desc!"
+			name = "-tf-user"
+			description = "automated test user"
 		}
 		resource "baremetal_identity_api_key" "t" {
 			user_id = "${baremetal_identity_user.t.id}"

--- a/resource_obmcs_identity_compartment_test.go
+++ b/resource_obmcs_identity_compartment_test.go
@@ -45,7 +45,7 @@ func (s *ResourceIdentityCompartmentTestSuite) SetupTest() {
 	s.Config = `
 		resource "baremetal_identity_compartment" "t" {
 			name = "test-compartment"
-			description = "newdesc!"
+			description = "automated test compartment"
 		}
 	`
 	s.Config += testProviderConfig()
@@ -53,7 +53,7 @@ func (s *ResourceIdentityCompartmentTestSuite) SetupTest() {
 	s.Res = &baremetal.Compartment{
 		ID:            "id!",
 		Name:          "test-compartment",
-		Description:   "newdesc!",
+		Description:   "automated test compartment",
 		CompartmentID: "cid!",
 		State:         baremetal.ResourceActive,
 		TimeCreated:   s.TimeCreated,

--- a/resource_obmcs_identity_group.go
+++ b/resource_obmcs_identity_group.go
@@ -90,7 +90,7 @@ func (s *GroupSync) DeletedTarget() []string {
 }
 
 func (s *GroupSync) ExtraWaitPostCreateDelete() time.Duration {
-	return time.Duration(20 * time.Second)
+	return time.Duration(2 * time.Second)
 }
 
 func (s *GroupSync) Create() (e error) {

--- a/resource_obmcs_identity_group_test.go
+++ b/resource_obmcs_identity_group_test.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"regexp"
 	"testing"
 	"time"
 
@@ -29,34 +28,22 @@ type ResourceIdentityGroupTestSuite struct {
 func (s *ResourceIdentityGroupTestSuite) SetupTest() {
 	s.Client = GetTestProvider()
 
-	configfn := func(d *schema.ResourceData) (interface{}, error) {
+	s.Provider = Provider(func(d *schema.ResourceData) (interface{}, error) {
 		return s.Client, nil
-	}
+	})
 
-	s.Provider = Provider(configfn)
 	s.Providers = map[string]terraform.ResourceProvider{
 		"baremetal": s.Provider,
 	}
 	s.TimeCreated, _ = time.Parse("2006-Jan-02", "2006-Jan-02")
-	s.Config = `
+	s.Config = testProviderConfig() + `
 		resource "baremetal_identity_group" "t" {
-			name = "groupname"
-			description = "group desc!"
+			name = "-tf-group"
+			description = "automated test group"
 		}
 	`
 
-	s.Config += testProviderConfig()
-
 	s.ResourceName = "baremetal_identity_group.t"
-	s.Res = &baremetal.Group{
-		ID:            "id!",
-		Name:          "groupname",
-		Description:   "group desc!",
-		CompartmentID: "cid!",
-		State:         baremetal.ResourceActive,
-		TimeCreated:   s.TimeCreated,
-	}
-
 }
 
 func (s *ResourceIdentityGroupTestSuite) TestCreateResourceIdentityGroup() {
@@ -69,118 +56,23 @@ func (s *ResourceIdentityGroupTestSuite) TestCreateResourceIdentityGroup() {
 				ImportStateVerify: true,
 				Config:            s.Config,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(s.ResourceName, "name", s.Res.Name),
-					resource.TestCheckResourceAttr(s.ResourceName, "description", s.Res.Description),
+					resource.TestCheckResourceAttr(s.ResourceName, "name", "-tf-group"),
+					resource.TestCheckResourceAttr(s.ResourceName, "description", "automated test group"),
 
-					resource.TestCheckResourceAttr(s.ResourceName, "state", s.Res.State),
+					resource.TestCheckResourceAttr(s.ResourceName, "state", baremetal.ResourceActive),
 					resource.TestCheckResourceAttrSet(s.ResourceName, "time_created"),
 				),
 			},
-		},
-	})
-}
-
-func (s *ResourceIdentityGroupTestSuite) TestCreateResourceIdentityGroupPolling() {
-	s.Res.State = baremetal.ResourceCreating
-
-	u := *s.Res
-	u.State = baremetal.ResourceActive
-
-	resource.UnitTest(s.T(), resource.TestCase{
-		Providers: s.Providers,
-		Steps: []resource.TestStep{
 			{
-				ImportState:       true,
-				ImportStateVerify: true,
-				Config:            s.Config,
-				Check:             resource.TestCheckResourceAttr(s.ResourceName, "state", baremetal.ResourceActive),
-			},
-		},
-	})
-}
-
-func (s *ResourceIdentityGroupTestSuite) TestUpdateResourceIdentityGroupDescription() {
-
-	c := `
-		resource "baremetal_identity_group" "t" {
-			name = "groupname"
-			description = "newdesc!"
-		}
-	`
-
-	c += testProviderConfig()
-
-	resource.UnitTest(s.T(), resource.TestCase{
-		Providers: s.Providers,
-		Steps: []resource.TestStep{
-			{
-				ImportState:       true,
-				ImportStateVerify: true,
-				Config:            s.Config,
-			},
-			{
-				Config: c,
+				Config: testProviderConfig() + `
+					resource "baremetal_identity_group" "t" {
+						name = "-tf-group"
+						description = "automated test group (updated)"
+					}
+				`,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(s.ResourceName, "description", "newdesc!"),
+					resource.TestCheckResourceAttr(s.ResourceName, "description", "automated test group (updated)"),
 				),
-			},
-		},
-	})
-}
-
-func (s *ResourceIdentityGroupTestSuite) TestFailedUpdateResourceIdentityGroupDescription() {
-
-	c := `
-		resource "baremetal_identity_group" "t" {
-			name = "groupname"
-			description = "newdesc!"
-		}
-	`
-	c += testProviderConfig()
-
-	resource.UnitTest(s.T(), resource.TestCase{
-		Providers: s.Providers,
-		Steps: []resource.TestStep{
-			{
-				ImportState:       true,
-				ImportStateVerify: true,
-				Config:            s.Config,
-			},
-			{
-				Config:      c,
-				ExpectError: regexp.MustCompile(`FAILED`),
-				Check:       resource.TestCheckResourceAttr(s.ResourceName, "description", "newdesc!"),
-			},
-			{
-				Config: c,
-				Check:  resource.TestCheckResourceAttr(s.ResourceName, "description", "newdesc!"),
-			},
-		},
-	})
-}
-
-func (s *ResourceIdentityGroupTestSuite) TestUpdateResourceIdentityGroupNameShouldCreateNew() {
-
-	c := `
-		resource "baremetal_identity_group" "t" {
-			name = "groupname2"
-			description = "desc!"
-		}
-	`
-
-	c += testProviderConfig()
-
-	resource.UnitTest(s.T(), resource.TestCase{
-		Providers: s.Providers,
-		Steps: []resource.TestStep{
-			{
-				ImportState:       true,
-				ImportStateVerify: true,
-				Config:            s.Config,
-			},
-			{
-				Config: c,
-				Check:  resource.TestCheckResourceAttr(s.ResourceName, "name", "groupname2"),
 			},
 		},
 	})

--- a/resource_obmcs_identity_policy_test.go
+++ b/resource_obmcs_identity_policy_test.go
@@ -37,20 +37,18 @@ func (s *ResourceIdentityPolicyTestSuite) SetupTest() {
 	s.TimeCreated, _ = time.Parse("2006-Jan-02", "2006-Jan-02")
 	s.Config = `
 	resource "baremetal_identity_group" "t" {
-		name = "HelpDesk"
-		description = "group desc!"
+		name = "-tf-group"
+		description = "automated test group"
 	}
 	data "baremetal_identity_compartments" "t" {
-     		compartment_id = "${var.compartment_id}"
-        }
-	  resource "baremetal_identity_policy" "p" {
-	    name = "HelpdeskUsers"
-	    description = "description"
-	    compartment_id = "${data.baremetal_identity_compartments.t.compartments.0.id}"
-	    statements = ["Allow group HelpDesk to read instances in compartment ${data.baremetal_identity_compartments.t.compartments.0.name}"]
-
-	    depends_on = ["baremetal_identity_group.t"]
-	  }
+		compartment_id = "${var.compartment_id}"
+	}
+	resource "baremetal_identity_policy" "p" {
+		name = "-tf-policy"
+		description = "automated test policy"
+		compartment_id = "${data.baremetal_identity_compartments.t.compartments.0.id}"
+		statements = ["Allow group ${baremetal_identity_group.t.name} to read instances in compartment ${data.baremetal_identity_compartments.t.compartments.0.name}"]
+	}
 	`
 	s.Config += testProviderConfig()
 	s.PolicyName = "baremetal_identity_policy.p"
@@ -69,6 +67,7 @@ func (s *ResourceIdentityPolicyTestSuite) TestCreateResourceIdentityPolicy() {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(s.PolicyName, "id"),
 					resource.TestCheckResourceAttrSet(s.PolicyName, "time_created"),
+					resource.TestCheckResourceAttr(s.PolicyName, "statements.#", "1"),
 				),
 			},
 		},

--- a/resource_obmcs_identity_swift_password_test.go
+++ b/resource_obmcs_identity_swift_password_test.go
@@ -76,12 +76,12 @@ func (s *ResourceIdentitySwiftPasswordTestSuite) TestCreateSwiftPassword() {
 func (s ResourceIdentitySwiftPasswordTestSuite) TestUpdateDescriptionUpdatesSwiftPassword() {
 	config := `
 		resource "baremetal_identity_user" "t" {
-			name = "name1"
-			description = "desc!"
+			name = "-tf-user"
+			description = "automated test user"
 		}
 		resource "baremetal_identity_swift_password" "t" {
 			user_id = "${baremetal_identity_user.t.id}"
-			description = "nah nah nah"
+			description = "automated test swift password"
 		}
   `
 	config += testProviderConfig()
@@ -100,7 +100,7 @@ func (s ResourceIdentitySwiftPasswordTestSuite) TestUpdateDescriptionUpdatesSwif
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(s.ResourceName, "description", "nah nah nah"),
+					resource.TestCheckResourceAttr(s.ResourceName, "description", "automated test swift password"),
 				),
 			},
 		},

--- a/resource_obmcs_identity_ui_password_test.go
+++ b/resource_obmcs_identity_ui_password_test.go
@@ -40,12 +40,11 @@ func (s *ResourceIdentityUIPasswordTestSuite) SetupTest() {
 
 	s.Config = `
 		resource "baremetal_identity_user" "t" {
-			name = "name1"
-			description = "desc!"
+			name = "-tf-user"
+			description = "automated test user"
 		}
 		resource "baremetal_identity_ui_password" "t" {
 			user_id = "${baremetal_identity_user.t.id}"
-			version = "1"
 		}
 	`
 	s.Config += testProviderConfig()
@@ -74,12 +73,11 @@ func (s *ResourceIdentityUIPasswordTestSuite) TestCreateUIPassword() {
 func (s ResourceIdentityUIPasswordTestSuite) TestUpdateVersionForcesNewUIPassword() {
 	config := `
 		resource "baremetal_identity_user" "t" {
-			name = "name1"
-			description = "desc!"
+			name = "-tf-user"
+			description = "automated test user"
 		}
 		resource "baremetal_identity_ui_password" "t" {
 			user_id = "${baremetal_identity_user.t.id}"
-			version = "2"
 		}
   `
 	config += testProviderConfig()

--- a/resource_obmcs_identity_user_group_membership_test.go
+++ b/resource_obmcs_identity_user_group_membership_test.go
@@ -31,19 +31,19 @@ func (s *ResourceIdentityUserGroupMembershipTestSuite) SetupTest() {
 	}
 
 	s.Config = `
-    resource "baremetal_identity_user" "u" {
-	name = "user_name"
-	description = "user desc"
-    }
-    resource "baremetal_identity_group" "g" {
-	name = "group_name"
-	description = "group desc"
-    }
-    resource "baremetal_identity_user_group_membership" "ug_membership" {
-    	compartment_id = "${var.tenancy_ocid}"
-	user_id = "${baremetal_identity_user.u.id}"
-	group_id = "${baremetal_identity_group.g.id}"
-    }
+	resource "baremetal_identity_user" "u" {
+		name = "-tf-user"
+		description = "automated test user"
+	}
+	resource "baremetal_identity_group" "g" {
+		name = "-tf-group"
+		description = "automated test group"
+	}
+	resource "baremetal_identity_user_group_membership" "ug_membership" {
+		compartment_id = "${var.tenancy_ocid}"
+		user_id = "${baremetal_identity_user.u.id}"
+		group_id = "${baremetal_identity_group.g.id}"
+	}
   `
 	s.Config += testProviderConfig()
 	s.ResourceName = "baremetal_identity_user_group_membership.ug_membership"

--- a/resource_obmcs_identity_user_test.go
+++ b/resource_obmcs_identity_user_test.go
@@ -40,8 +40,8 @@ func (s *ResourceIdentityUserTestSuite) SetupTest() {
 	s.TimeCreated, _ = time.Parse("2006-Jan-02", "2006-Jan-02")
 	s.Config = `
 		resource "baremetal_identity_user" "t" {
-			name = "name1"
-			description = "desc!"
+			name = "-tf-user"
+			description = "automated test user"
 		}
 	`
 	s.Config += testProviderConfig()
@@ -49,8 +49,8 @@ func (s *ResourceIdentityUserTestSuite) SetupTest() {
 	s.ResourceName = "baremetal_identity_user.t"
 	s.Res = &baremetal.User{
 		ID:            "id!",
-		Name:          "name1",
-		Description:   "desc!",
+		Name:          "-tf-user",
+		Description:   "automated test user",
 		CompartmentID: "cid!",
 		State:         baremetal.ResourceActive,
 		TimeCreated:   s.TimeCreated,
@@ -106,10 +106,9 @@ func (s *ResourceIdentityUserTestSuite) TestCreateResourceIdentityUserPolling() 
 func (s *ResourceIdentityUserTestSuite) TestUpdateResourceIdentityUserDescription() {
 
 	c := `
-
 		resource "baremetal_identity_user" "t" {
-			name = "name1"
-			description = "newdesc!"
+			name = "-tf-user"
+			description = "automated test user updated"
 		}
 	`
 	c += testProviderConfig()
@@ -125,7 +124,7 @@ func (s *ResourceIdentityUserTestSuite) TestUpdateResourceIdentityUserDescriptio
 			{
 				Config: c,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(s.ResourceName, "description", "newdesc!"),
+					resource.TestCheckResourceAttr(s.ResourceName, "description", "automated test user updated"),
 				),
 			},
 		},
@@ -136,8 +135,8 @@ func (s *ResourceIdentityUserTestSuite) TestUpdateResourceIdentityUserNameShould
 
 	c := `
 		resource "baremetal_identity_user" "t" {
-			name = "newname1"
-			description = "desc!"
+			name = "-tf-user2"
+			description = "automated test user"
 		}
 	`
 
@@ -154,7 +153,7 @@ func (s *ResourceIdentityUserTestSuite) TestUpdateResourceIdentityUserNameShould
 			{
 				Config: c,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(s.ResourceName, "name", "newname1"),
+					resource.TestCheckResourceAttr(s.ResourceName, "name", "-tf-user2"),
 				),
 			},
 		},


### PR DESCRIPTION
* consistent naming between resources and datasources
* update policy example
* add convenience makefile commands `make show_tests`, `make run_one` and `make run_one_debug`

TESTS:
* commands for running each affected acceptance test:
```
make run_one test=TestDatasourceIdentityAPIKeysTestSuite
make run_one test=TestDatasourceIdentityAvailabilityDomainsTestSuite
make run_one test=TestDatasourceIdentityCompartmentsTestSuite
make run_one test=TestDatasourceIdentityGroupsTestSuite
make run_one test=TestDatasourceIdentityPoliciesTestSuite
make run_one test=TestDatasourceIdentitySwiftPasswordsTestSuite
make run_one test=TestDatasourceIdentityUserGroupMembershipsTestSuite
make run_one test=TestDatasourceIdentityUsersTestSuite
make run_one test=TestResourceIdentityAPIKeyTestSuite
make run_one test=TestResourceIdentityCompartmentTestSuite
make run_one test=TestResourceIdentityGroupTestSuite
make run_one test=TestResourceIdentityPolicyTestSuite
make run_one test=TestResourceIdentitySwiftPasswordTestSuite
make run_one test=TestResourceIdentityUIPasswordTestSuite
make run_one test=TestResourceIdentityUserGroupMembershipTestSuite
make run_one test=TestResourceIdentityUserTestSuite
```