### PR TITLE
Fixing size_in_mbs attribute in volume so that it doesn't force a recreation on each apply when not provided

### DIFF
--- a/resource_obmcs_core_volume.go
+++ b/resource_obmcs_core_volume.go
@@ -34,6 +34,7 @@ func VolumeResource() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 			"display_name": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Fixing size_in_mbs attribute in volume so that it doesn't force a recreation on each apply when not provided