### PR TITLE
Multi-VNIC support

### DIFF
--- a/data_source_obmcs_core_vnic.go
+++ b/data_source_obmcs_core_vnic.go
@@ -37,6 +37,14 @@ func VnicDatasource() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"is_primary": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"mac_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"state": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -50,6 +58,10 @@ func VnicDatasource() *schema.Resource {
 				Computed: true,
 			},
 			"subnet_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"time_created": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -85,10 +97,13 @@ func (v *VnicDatasourceCrud) SetData() {
 		v.D.Set("compartment_id", v.Resource.CompartmentID)
 		v.D.Set("display_name", v.Resource.DisplayName)
 		v.D.Set("hostname_label", v.Resource.HostnameLabel)
+		v.D.Set("is_primary", v.Resource.IsPrimary)
+		v.D.Set("mac_address", v.Resource.MacAddress)
 		v.D.Set("state", v.Resource.State)
 		v.D.Set("private_ip_address", v.Resource.PrivateIPAddress)
 		v.D.Set("public_ip_address", v.Resource.PublicIPAddress)
 		v.D.Set("subnet_id", v.Resource.SubnetID)
+		v.D.Set("time_created", v.Resource.TimeCreated.String())
 	}
 	return
 }

--- a/data_source_obmcs_core_vnic_test.go
+++ b/data_source_obmcs_core_vnic_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+
+package main
+
+import (
+	"testing"
+
+	baremetal "github.com/MustWin/baremetal-sdk-go"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/stretchr/testify/suite"
+)
+
+type DataSourceCoreVnicTestSuite struct {
+	suite.Suite
+	Client       *baremetal.Client
+	Config       string
+	Provider     terraform.ResourceProvider
+	Providers    map[string]terraform.ResourceProvider
+	ResourceName string
+}
+
+func (s *DataSourceCoreVnicTestSuite) SetupTest() {
+	s.Client = GetTestProvider()
+	s.Provider = Provider(func(d *schema.ResourceData) (interface{}, error) {
+		return s.Client, nil
+	})
+
+	s.Providers = map[string]terraform.ResourceProvider{
+		"baremetal": s.Provider,
+	}
+
+	s.Config = instanceDnsConfig
+	s.Config += testProviderConfig()
+	s.ResourceName = "data.baremetal_core_vnic.v"
+}
+
+func (s *DataSourceCoreVnicTestSuite) TestAttachVnic() {
+
+	resource.UnitTest(s.T(), resource.TestCase{
+		Providers: s.Providers,
+		Steps: []resource.TestStep{
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				Config: s.Config + `
+						data "baremetal_core_vnic_attachments" "va" {
+						  compartment_id = "${var.compartment_id}"
+						  instance_id = "${baremetal_core_instance.t.id}"
+						}
+						data "baremetal_core_vnic" "v" {
+						  vnic_id = "${lookup(data.baremetal_core_vnic_attachments.va.vnic_attachments[0],"vnic_id")}"
+						}
+					`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(s.ResourceName, "id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "availability_domain"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "compartment_id"),
+					resource.TestCheckResourceAttr(s.ResourceName, "display_name", "-tf-instance-vnic"),
+					resource.TestCheckResourceAttr(s.ResourceName, "hostname_label", "testinstance"),
+					resource.TestCheckResourceAttr(s.ResourceName, "is_primary", "true"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "mac_address"),
+					resource.TestCheckResourceAttr(s.ResourceName, "state", baremetal.ResourceAvailable),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "public_ip_address"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "subnet_id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "time_created"),
+				),
+			},
+		},
+	})
+}
+
+func TestDataSourceCoreVnicTestSuite(t *testing.T) {
+	suite.Run(t, new(DataSourceCoreVnicTestSuite))
+}

--- a/docs/datasources/core/vnic.md
+++ b/docs/datasources/core/vnic.md
@@ -24,8 +24,10 @@ The following attributes are exported:
 * `availability_domain` - The VNIC's Availability Domain.
 * `display_name` - A user-friendly name. Does not have to be unique.
 * `id` - The OCID of the VNIC.
-* `hostname_label` - The hostname for the VNIC that is created during instance launch. Used for DNS. .
+* `hostname_label` - The hostname for the VNIC that is created during instance launch. Used for DNS.
+* `is_primary` - Whether the VNIC is the primary VNIC (the VNIC that is automatically created and attached during instance launch).
 * `state` - The current state of the VNIC. [PROVISIONING, AVAILABLE, TERMINATING, TERMINATED]
+* `mac_address` - The MAC address of the VNIC.
 * `private_ip_address` - The private IP addresses of the VNIC, which is within the VNIC subnet and is accessible within the VCN.
 * `public_ip_address` - The public IP address of the VNIC, which Oracle performs NAT for at the gateway.
 * `subnet_id` - The OCID of the subnet the VNIC is in.

--- a/docs/examples/compute/multi_vnic/multi_vnic.tf
+++ b/docs/examples/compute/multi_vnic/multi_vnic.tf
@@ -1,0 +1,132 @@
+variable "tenancy_ocid" {}
+variable "user_ocid" {}
+variable "fingerprint" {}
+variable "private_key_path" {}
+variable "compartment_ocid" {}
+variable "region" {}
+variable "ssh_public_key" {}
+
+variable "SecondaryVnicCount" {
+    default = 2
+}
+
+# Choose an Availability Domain
+variable "AD" {
+    default = "1"
+}
+
+variable "InstanceShape" {
+    default = "VM.Standard1.8"
+}
+
+variable "InstanceOS" {
+    default = "Oracle Linux"
+}
+
+variable "InstanceOSVersion" {
+    default = "7.3"
+}
+
+provider "baremetal" {
+  tenancy_ocid = "${var.tenancy_ocid}"
+  user_ocid = "${var.user_ocid}"
+  fingerprint = "${var.fingerprint}"
+  private_key_path = "${var.private_key_path}"
+  region = "${var.region}"
+}
+
+data "baremetal_identity_availability_domains" "ADs" {
+  compartment_id = "${var.tenancy_ocid}"
+}
+
+resource "baremetal_core_virtual_network" "ExampleVCN" {
+  cidr_block = "10.0.0.0/16"
+  compartment_id = "${var.compartment_ocid}"
+  display_name = "CompleteVCN"
+  dns_label = "examplevcn"
+}
+
+resource "baremetal_core_subnet" "ExampleSubnet" {
+  availability_domain = "${lookup(data.baremetal_identity_availability_domains.ADs.availability_domains[var.AD - 1],"name")}"
+  cidr_block = "10.0.1.0/24"
+  display_name = "ExampleSubnet"
+  compartment_id = "${var.compartment_ocid}"
+  vcn_id = "${baremetal_core_virtual_network.ExampleVCN.id}"
+  route_table_id = "${baremetal_core_virtual_network.ExampleVCN.default_route_table_id}"
+  security_list_ids = ["${baremetal_core_virtual_network.ExampleVCN.default_security_list_id}"]
+  dhcp_options_id = "${baremetal_core_virtual_network.ExampleVCN.default_dhcp_options_id}"
+  dns_label = "examplesubnet"
+}
+
+# Gets the OCID of the OS image to use
+data "baremetal_core_images" "OLImageOCID" {
+    compartment_id = "${var.compartment_ocid}"
+    operating_system = "${var.InstanceOS}"
+    operating_system_version = "${var.InstanceOSVersion}"
+}
+
+resource "baremetal_core_instance" "ExampleInstance" {
+  availability_domain = "${lookup(data.baremetal_identity_availability_domains.ADs.availability_domains[var.AD - 1],"name")}"
+  compartment_id = "${var.compartment_ocid}"
+  display_name = "ExampleInstance"
+  image = "${lookup(data.baremetal_core_images.OLImageOCID.images[0], "id")}"
+  shape = "${var.InstanceShape}"
+  subnet_id = "${baremetal_core_subnet.ExampleSubnet.id}"
+  create_vnic_details {
+    subnet_id = "${baremetal_core_subnet.ExampleSubnet.id}"
+    hostname_label = "exampleinstance"
+  }
+  metadata {
+    ssh_authorized_keys = "${var.ssh_public_key}"
+  }
+
+  timeouts {
+    create = "60m"
+  }
+}
+
+resource "baremetal_core_vnic_attachment" "PrivateVnicAttachment" {
+  instance_id = "${baremetal_core_instance.ExampleInstance.id}"
+  create_vnic_details {
+    subnet_id = "${baremetal_core_subnet.ExampleSubnet.id}"
+    display_name = "PrivateVnic"
+    assign_public_ip = false
+  }
+}
+
+resource "baremetal_core_vnic_attachment" "SecondaryVnicAttachment" {
+  instance_id = "${baremetal_core_instance.ExampleInstance.id}"
+  display_name = "SecondaryVnicAttachment_${count.index}"
+  create_vnic_details {
+    subnet_id = "${baremetal_core_subnet.ExampleSubnet.id}"
+    display_name = "SecondaryVnic_${count.index}"
+    assign_public_ip = true
+  }
+  count = "${var.SecondaryVnicCount}"
+}
+
+data "baremetal_core_vnic" "SecondaryVnic" {
+  count = "${var.SecondaryVnicCount}"
+  vnic_id = "${element(baremetal_core_vnic_attachment.SecondaryVnicAttachment.*.vnic_id, count.index)}"
+}
+
+output "PrimaryIPAddresses" {
+  value = ["${baremetal_core_instance.ExampleInstance.public_ip}",
+           "${baremetal_core_instance.ExampleInstance.private_ip}"]
+}
+
+output "SecondaryPublicIPAddresses" {
+  value = ["${data.baremetal_core_vnic.SecondaryVnic.*.public_ip_address}"]
+}
+
+output "SecondaryPrivateIPAddresses" {
+  value = ["${data.baremetal_core_vnic.SecondaryVnic.*.private_ip_address}"]
+}
+
+data "baremetal_core_vnic" "PrivateVnic" {
+  vnic_id = "${baremetal_core_vnic_attachment.PrivateVnicAttachment.vnic_id}"
+}
+
+output "PrivateVnicIPAddresses" {
+  value = ["${data.baremetal_core_vnic.PrivateVnic.private_ip_address}", "${data.baremetal_core_vnic.PrivateVnic.public_ip_address}"]
+}

--- a/docs/examples/compute/multi_vnic/multi_vnic.tf
+++ b/docs/examples/compute/multi_vnic/multi_vnic.tf
@@ -85,15 +85,6 @@ resource "baremetal_core_instance" "ExampleInstance" {
   }
 }
 
-resource "baremetal_core_vnic_attachment" "PrivateVnicAttachment" {
-  instance_id = "${baremetal_core_instance.ExampleInstance.id}"
-  create_vnic_details {
-    subnet_id = "${baremetal_core_subnet.ExampleSubnet.id}"
-    display_name = "PrivateVnic"
-    assign_public_ip = false
-  }
-}
-
 resource "baremetal_core_vnic_attachment" "SecondaryVnicAttachment" {
   instance_id = "${baremetal_core_instance.ExampleInstance.id}"
   display_name = "SecondaryVnicAttachment_${count.index}"
@@ -121,12 +112,4 @@ output "SecondaryPublicIPAddresses" {
 
 output "SecondaryPrivateIPAddresses" {
   value = ["${data.baremetal_core_vnic.SecondaryVnic.*.private_ip_address}"]
-}
-
-data "baremetal_core_vnic" "PrivateVnic" {
-  vnic_id = "${baremetal_core_vnic_attachment.PrivateVnicAttachment.vnic_id}"
-}
-
-output "PrivateVnicIPAddresses" {
-  value = ["${data.baremetal_core_vnic.PrivateVnic.private_ip_address}", "${data.baremetal_core_vnic.PrivateVnic.public_ip_address}"]
 }

--- a/docs/resources/core/vnic_attachment.md
+++ b/docs/resources/core/vnic_attachment.md
@@ -20,16 +20,16 @@ resource "baremetal_core_vnic_attachment" "t" {
 
 The following arguments are supported:
 
-* `display_name` - A user-friendly name. Does not have to be unique.
+* `display_name` - (Optional) A user-friendly name. Does not have to be unique.
 * `instance_id` - (Required) The OCID of the instance.
 * `create_vnic_details` - (Required) Details for creating a new VNIC. See [Create Vnic Details](https://docs.us-phoenix-1.oraclecloud.com/api/#/en/iaas/20160918/requests/CreateVnicDetails).
 
 ## Create VNIC Details Argument Reference
 
-* `assign_public_ip` - Whether the VNIC should be assigned a public IP address.
-* `display_name` - A user-friendly name for the VNIC. Does not have to be unique.
-* `hostname_label` - The hostname for the VNIC's primary private IP.
-* `private_p` - A private IP address of your choice to assign to the VNIC.
+* `assign_public_ip` - (Optional) Whether the VNIC should be assigned a public IP address.
+* `display_name` - (Optional) A user-friendly name for the VNIC. Does not have to be unique.
+* `hostname_label` - (Optional) The hostname for the VNIC's primary private IP.
+* `private_ip` - (Optional) A private IP address of your choice to assign to the VNIC.
 * `subnet_id` - (Required) The OCID of the subnet to create the VNIC in.
 
 ## Attributes Reference

--- a/docs/resources/core/vnic_attachment.md
+++ b/docs/resources/core/vnic_attachment.md
@@ -1,0 +1,46 @@
+# baremetal\_core\_vnic\_attachment
+
+Provides a VNIC attachment resource
+
+## Example Usage
+
+```
+resource "baremetal_core_vnic_attachment" "t" {
+  instance_id = "${var.instance_id}"
+  display_name = "secondary_vnic_attachment"
+  create_vnic_details {
+    subnet_id = "${var.subnet_id}"
+    display_name = "secondary_vnic"
+    assign_public_ip = true
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `display_name` - A user-friendly name. Does not have to be unique.
+* `instance_id` - (Required) The OCID of the instance.
+* `create_vnic_details` - (Required) Details for creating a new VNIC. See [Create Vnic Details](https://docs.us-phoenix-1.oraclecloud.com/api/#/en/iaas/20160918/requests/CreateVnicDetails).
+
+## Create VNIC Details Argument Reference
+
+* `assign_public_ip` - Whether the VNIC should be assigned a public IP address.
+* `display_name` - A user-friendly name for the VNIC. Does not have to be unique.
+* `hostname_label` - The hostname for the VNIC's primary private IP.
+* `private_p` - A private IP address of your choice to assign to the VNIC.
+* `subnet_id` - (Required) The OCID of the subnet to create the VNIC in.
+
+## Attributes Reference
+
+* `availability_domain` - The VNIC Attachment's Availability Domain.
+* `compartment_id` - The OCID of the compartment the VNIC attachment is in, which is the same compartment the instance is in.
+* `display_name` - A user-friendly name. Does not have to be unique.
+* `id` - The OCID of the VNIC Attachment.
+* `instance_id` - The OCID of the instance.
+* `state` - The current state of the VNIC attachment. [ATTACHING, ATTACHED, DETACHING, DETACHED].
+* `subnet_id` - The OCID of the VNIC's subnet.
+* `time_created` - The date and time the VNIC attachment was created, in the format defined by RFC3339.
+* `vlan_tag` - The Oracle-assigned VLAN tag of the attached VNIC. Available after the attachment process is complete.
+* `vnic_id` - The OCID of the VNIC.

--- a/docs/resources/core/volume_attachment.md
+++ b/docs/resources/core/volume_attachment.md
@@ -1,6 +1,6 @@
 # baremetal\_core\_volume\_attachment
 
-Provides a volue attachment resource
+Provides a volume attachment resource
 
 ## Example Usage
 
@@ -17,7 +17,7 @@ resource "baremetal_core_volume_attachment" "t" {
 
 The following arguments are supported:
 
-* `display_name` - (Required) The OCID of the compartment.
+* `display_name` - (Required) A user-friendly name. Does not have to be unique, and it cannot be changed.
 * `instance_id` - (Required) The OCID of the instance.
 * `volume_id` - (Required) The OCID of the volume.
 * `type` - (Required) The type of volume. The only supported value is "iscsi".

--- a/helpers_core.go
+++ b/helpers_core.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+
+package main
+
+import "github.com/MustWin/baremetal-sdk-go"
+
+func SetCreateVnicOptions(rawCreateVnicDetails interface{}) (vnicOpts *baremetal.CreateVnicOptions) {
+	vnic := rawCreateVnicDetails.(map[string]interface{})
+
+	vnicOpts = &baremetal.CreateVnicOptions{}
+	vnicOpts.SubnetID = vnic["subnet_id"].(string)
+
+	displayName := vnic["display_name"]
+	if displayName != nil {
+		vnicOpts.DisplayName = displayName.(string)
+	}
+
+	hostnameLabel := vnic["hostname_label"]
+	if hostnameLabel != nil {
+		vnicOpts.HostnameLabel = hostnameLabel.(string)
+	}
+
+	privateIp := vnic["private_ip"]
+	if privateIp != nil {
+		vnicOpts.PrivateIp = privateIp.(string)
+	}
+
+	//todo: work around for tf bug https://github.com/hashicorp/terraform/issues/13512
+	assignPublicIp := vnic["assign_public_ip"]
+	if assignPublicIp != nil {
+		vnicOpts.AssignPublicIp = new(bool)
+		*vnicOpts.AssignPublicIp = assignPublicIp.(string) == "1"
+	}
+
+	return
+}

--- a/provider.go
+++ b/provider.go
@@ -173,6 +173,7 @@ func resourcesMap() map[string]*schema.Resource {
 		"baremetal_core_security_list":             SecurityListResource(),
 		"baremetal_core_subnet":                    SubnetResource(),
 		"baremetal_core_virtual_network":           VirtualNetworkResource(),
+		"baremetal_core_vnic_attachment":           VnicAttachmentResource(),
 		"baremetal_core_volume":                    VolumeResource(),
 		"baremetal_core_volume_attachment":         VolumeAttachmentResource(),
 		"baremetal_core_volume_backup":             VolumeBackupResource(),

--- a/resource_obmcs_core_instance.go
+++ b/resource_obmcs_core_instance.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
 
 	"github.com/MustWin/baremetal-sdk-go"
@@ -116,7 +117,7 @@ func InstanceResource() *schema.Resource {
 			},
 			"subnet_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 			"time_created": {
@@ -248,34 +249,7 @@ func (s *InstanceResourceCrud) Create() (e error) {
 	}
 
 	if rawVnic, ok := s.D.GetOk("create_vnic_details"); ok {
-		vnic := rawVnic.(map[string]interface{})
-
-		vnicOpts := &baremetal.CreateVnicOptions{}
-		vnicOpts.SubnetID = vnic["subnet_id"].(string)
-
-		displayName := vnic["display_name"]
-		if displayName != nil {
-			vnicOpts.DisplayName = displayName.(string)
-		}
-
-		hostnameLabel := vnic["hostname_label"]
-		if hostnameLabel != nil {
-			vnicOpts.HostnameLabel = hostnameLabel.(string)
-		}
-
-		privateIp := vnic["private_ip"]
-		if privateIp != nil {
-			vnicOpts.PrivateIp = privateIp.(string)
-		}
-
-		//todo: work around for tf bug https://github.com/hashicorp/terraform/issues/13512
-		assignPublicIp := vnic["assign_public_ip"]
-		if assignPublicIp != nil {
-			vnicOpts.AssignPublicIp = new(bool)
-			*vnicOpts.AssignPublicIp = assignPublicIp.(string) == "1"
-		}
-
-		opts.CreateVnicOptions = vnicOpts
+		opts.CreateVnicOptions = SetCreateVnicOptions(rawVnic)
 	}
 
 	s.Resource, e = s.Client.LaunchInstance(
@@ -289,51 +263,47 @@ func (s *InstanceResourceCrud) Create() (e error) {
 }
 
 /*
- * Return the id of the first VNIC attached to this Instance.
- *
- * NOTE while the instance is still being created, calls to this function
- * can return  an error priort to the Vnic being attached.
- */
-func (s *InstanceResourceCrud) getInstanceVnicId() (vnic_id string, e error) {
-	compartmentID := s.Resource.CompartmentID
-
-	opts := &baremetal.ListVnicAttachmentsOptions{}
-	options.SetListOptions(s.D, &opts.ListOptions)
-	opts.AvailabilityDomain = s.Resource.AvailabilityDomain
-	opts.InstanceID = s.Resource.ID
-
-	var list *baremetal.ListVnicAttachments
-	if list, e = s.Client.ListVnicAttachments(compartmentID, opts); e != nil {
-		return "", e
-	}
-
-	if len(list.Attachments) < 1 {
-		log.Printf("[DEBUG] GetInstanceVnicID - InstanceID: %q, State: %q, no vnic attachments: %q", s.Resource.ID, s.Resource.State, e)
-		return "", e
-	}
-
-	return list.Attachments[0].VnicID, nil
-}
-
-/*
- * Return the public, private IP pair associated with the instance's first Vnic.
+ * Return the public, private IP pair associated with the instance's primary Vnic.
  *
  * NOTE while the instance is still being created, calls to this function
  * can return  an error priort to the Vnic being attached.
  */
 func (s *InstanceResourceCrud) getInstanceIPs() (public_ip string, private_ip string, e error) {
-	vnicID, e := s.getInstanceVnicId()
-	if e != nil {
-		return "", "", e
+	compartmentID := s.Resource.CompartmentID
+
+	opts := &baremetal.ListVnicAttachmentsOptions{}
+	opts.InstanceID = s.Resource.ID
+
+	// Page through all VNIC attachments for the instance.
+	var attachments []baremetal.VnicAttachment
+	for {
+		var result *baremetal.ListVnicAttachments
+		if result, e = s.Client.ListVnicAttachments(compartmentID, opts); e != nil {
+			break
+		}
+
+		attachments = append(attachments, result.Attachments...)
+		if hasNextPage := options.SetNextPageOption(result.NextPage, &opts.ListOptions.PageListOptions); !hasNextPage {
+			break
+		}
 	}
 
-	// Lookup Vnic by id
-	vnic, e := s.Client.GetVnic(vnicID)
-	if e != nil {
-		return "", "", e
+	if len(attachments) < 1 {
+		return "", "", errors.New("No VNIC attachments found.")
 	}
 
-	return vnic.PublicIPAddress, vnic.PrivateIPAddress, nil
+	for _, attachment := range attachments {
+		if attachment.State == baremetal.ResourceAttached {
+			vnic, _ := s.Client.GetVnic(attachment.VnicID)
+
+			// Ignore errors on GetVnic, since we might not have permissions to view some secondary VNICs.
+			if vnic != nil && vnic.IsPrimary {
+				return vnic.PublicIPAddress, vnic.PrivateIPAddress, nil
+			}
+		}
+	}
+
+	return "", "", errors.New("Primary VNIC not found.")
 }
 
 func (s *InstanceResourceCrud) Get() (e error) {
@@ -347,7 +317,7 @@ func (s *InstanceResourceCrud) Get() (e error) {
 	// (Not available while state==PROVISIONING)
 	public_ip, private_ip, e2 := s.getInstanceIPs()
 	if e2 != nil {
-		log.Printf("[DEBUG] no vnic yet, skipping")
+		log.Printf("[DEBUG] Primary VNIC could not be found: %q (InstanceID: %q, State: %q)", e2, s.Resource.ID, s.Resource.State)
 	}
 
 	if public_ip != "" {

--- a/resource_obmcs_core_vnic_attachment.go
+++ b/resource_obmcs_core_vnic_attachment.go
@@ -97,7 +97,6 @@ func VnicAttachmentResource() *schema.Resource {
 				Computed: true,
 			},
 		},
-
 	}
 }
 
@@ -182,4 +181,3 @@ func (s *VnicAttachmentResourceCrud) SetData() {
 func (s *VnicAttachmentResourceCrud) Delete() (e error) {
 	return s.Client.DetachVnic(s.D.Id(), nil)
 }
-

--- a/resource_obmcs_core_vnic_attachment.go
+++ b/resource_obmcs_core_vnic_attachment.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+
+package main
+
+import (
+	"github.com/MustWin/baremetal-sdk-go"
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/oracle/terraform-provider-baremetal/crud"
+)
+
+func VnicAttachmentResource() *schema.Resource {
+	return &schema.Resource{
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: crud.DefaultTimeout,
+		Create:   createVnicAttachment,
+		Read:     readVnicAttachment,
+		Delete:   deleteVnicAttachment,
+		Schema: map[string]*schema.Schema{
+			"availability_domain": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"compartment_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"create_vnic_details": {
+				Type:     schema.TypeMap,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"assign_public_ip": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+						},
+						"display_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"hostname_label": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"private_ip": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"subnet_id": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+			"display_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+				ForceNew: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"subnet_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"time_created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vlan_tag": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"vnic_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+
+	}
+}
+
+func createVnicAttachment(d *schema.ResourceData, m interface{}) (e error) {
+	sync := &VnicAttachmentResourceCrud{}
+	sync.D = d
+	sync.Client = m.(*baremetal.Client)
+	return crud.CreateResource(d, sync)
+}
+
+func readVnicAttachment(d *schema.ResourceData, m interface{}) (e error) {
+	sync := &VnicAttachmentResourceCrud{}
+	sync.D = d
+	sync.Client = m.(*baremetal.Client)
+	return crud.ReadResource(sync)
+}
+
+func deleteVnicAttachment(d *schema.ResourceData, m interface{}) (e error) {
+	sync := &VnicAttachmentResourceCrud{}
+	sync.D = d
+	sync.Client = m.(*baremetal.Client)
+	return crud.DeleteResource(d, sync)
+}
+
+type VnicAttachmentResourceCrud struct {
+	crud.BaseCrud
+	Resource *baremetal.VnicAttachment
+}
+
+func (s *VnicAttachmentResourceCrud) ID() string {
+	return s.Resource.ID
+}
+
+func (s *VnicAttachmentResourceCrud) CreatedPending() []string {
+	return []string{baremetal.ResourceAttaching}
+}
+
+func (s *VnicAttachmentResourceCrud) CreatedTarget() []string {
+	return []string{baremetal.ResourceAttached}
+}
+
+func (s *VnicAttachmentResourceCrud) DeletedPending() []string {
+	return []string{baremetal.ResourceDetaching}
+}
+
+func (s *VnicAttachmentResourceCrud) DeletedTarget() []string {
+	return []string{baremetal.ResourceDetached}
+}
+
+func (s *VnicAttachmentResourceCrud) Create() (e error) {
+	instanceID := s.D.Get("instance_id").(string)
+
+	vaOpts := &baremetal.AttachVnicOptions{}
+	if displayName, ok := s.D.GetOk("display_name"); ok {
+		vaOpts.DisplayName = displayName.(string)
+	}
+
+	vnicOpts := SetCreateVnicOptions(s.D.Get("create_vnic_details"))
+
+	s.Resource, e = s.Client.AttachVnic(instanceID, vnicOpts, vaOpts)
+
+	return
+}
+
+func (s *VnicAttachmentResourceCrud) Get() (e error) {
+	s.Resource, e = s.Client.GetVnicAttachment(s.D.Id())
+	return
+}
+
+func (s *VnicAttachmentResourceCrud) SetData() {
+	s.D.Set("availability_domain", s.Resource.AvailabilityDomain)
+	s.D.Set("compartment_id", s.Resource.CompartmentID)
+	s.D.Set("display_name", s.Resource.DisplayName)
+	s.D.Set("instance_id", s.Resource.InstanceID)
+	s.D.Set("state", s.Resource.State)
+	s.D.Set("subnet_id", s.Resource.SubnetID)
+	s.D.Set("time_created", s.Resource.TimeCreated.String())
+	s.D.Set("vlan_tag", s.Resource.VlanTag)
+	s.D.Set("vnic_id", s.Resource.VnicID)
+}
+
+func (s *VnicAttachmentResourceCrud) Delete() (e error) {
+	return s.Client.DetachVnic(s.D.Id(), nil)
+}
+

--- a/resource_obmcs_core_vnic_attachment_test.go
+++ b/resource_obmcs_core_vnic_attachment_test.go
@@ -16,14 +16,14 @@ import (
 
 type ResourceCoreVnicAttachmentTestSuite struct {
 	suite.Suite
-	Client       *baremetal.Client
-	Provider     terraform.ResourceProvider
-	Providers    map[string]terraform.ResourceProvider
-	TimeCreated  baremetal.Time
-	Config       string
-	ResourceName string
+	Client           *baremetal.Client
+	Provider         terraform.ResourceProvider
+	Providers        map[string]terraform.ResourceProvider
+	TimeCreated      baremetal.Time
+	Config           string
+	ResourceName     string
 	VnicResourceName string
-	Res          *baremetal.VnicAttachment
+	Res              *baremetal.VnicAttachment
 }
 
 func (s *ResourceCoreVnicAttachmentTestSuite) SetupTest() {

--- a/resource_obmcs_core_vnic_attachment_test.go
+++ b/resource_obmcs_core_vnic_attachment_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MustWin/baremetal-sdk-go"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/stretchr/testify/suite"
+	"regexp"
+)
+
+type ResourceCoreVnicAttachmentTestSuite struct {
+	suite.Suite
+	Client       *baremetal.Client
+	Provider     terraform.ResourceProvider
+	Providers    map[string]terraform.ResourceProvider
+	TimeCreated  baremetal.Time
+	Config       string
+	ResourceName string
+	VnicResourceName string
+	Res          *baremetal.VnicAttachment
+}
+
+func (s *ResourceCoreVnicAttachmentTestSuite) SetupTest() {
+	s.Client = GetTestProvider()
+
+	s.Provider = Provider(
+		func(d *schema.ResourceData) (interface{}, error) {
+			return s.Client, nil
+		},
+	)
+
+	s.Providers = map[string]terraform.ResourceProvider{
+		"baremetal": s.Provider,
+	}
+
+	s.TimeCreated = baremetal.Time{Time: time.Now()}
+	s.Config = instanceDnsConfig
+	s.Config += testProviderConfig()
+	s.ResourceName = "baremetal_core_vnic_attachment.va"
+	s.VnicResourceName = "data.baremetal_core_vnic.v"
+}
+
+func (s *ResourceCoreVnicAttachmentTestSuite) TestAttachVnic() {
+
+	resource.UnitTest(s.T(), resource.TestCase{
+		Providers: s.Providers,
+		Steps: []resource.TestStep{
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				Config: s.Config + `
+						resource "baremetal_core_vnic_attachment" "va" {
+							instance_id = "${baremetal_core_instance.t.id}"
+							display_name = "-tf-va1"
+							create_vnic_details {
+								subnet_id = "${baremetal_core_subnet.t.id}"
+								display_name = "-tf-vnic"
+								assign_public_ip = false
+							}
+						}
+						data "baremetal_core_vnic" "v" {
+						  vnic_id = "${baremetal_core_vnic_attachment.va.vnic_id}"
+						}
+					`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(s.ResourceName, "availability_domain"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "compartment_id"),
+					resource.TestCheckResourceAttr(s.ResourceName, "display_name", "-tf-va1"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "instance_id"),
+					resource.TestCheckResourceAttr(s.ResourceName, "state", baremetal.ResourceAttached),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "instance_id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "subnet_id"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "time_created"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "vlan_tag"),
+					resource.TestCheckResourceAttrSet(s.ResourceName, "vnic_id"),
+					resource.TestCheckResourceAttrSet(s.VnicResourceName, "id"),
+					resource.TestCheckResourceAttr(s.VnicResourceName, "display_name", "-tf-vnic"),
+					resource.TestCheckResourceAttrSet(s.VnicResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(s.VnicResourceName, "public_ip_address", ""),
+				),
+			},
+			{
+				// Create a new VNIC and VNIC Attachment with private IP, hostname, and assign a public IP.
+				ImportState:       true,
+				ImportStateVerify: true,
+				Config: s.Config + `
+						resource "baremetal_core_vnic_attachment" "va" {
+							instance_id = "${baremetal_core_instance.t.id}"
+							display_name = "-tf-va1"
+							create_vnic_details {
+								subnet_id = "${baremetal_core_subnet.t.id}"
+								display_name = "-tf-vnic"
+								assign_public_ip = true
+								private_ip = "10.0.1.20"
+								hostname_label = "myvnichostname"
+							}
+						}
+						data "baremetal_core_vnic" "v" {
+						  vnic_id = "${baremetal_core_vnic_attachment.va.vnic_id}"
+						}
+					`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(s.ResourceName, "state", baremetal.ResourceAttached),
+					resource.TestCheckResourceAttrSet(s.VnicResourceName, "id"),
+					resource.TestCheckResourceAttr(s.VnicResourceName, "private_ip_address", "10.0.1.20"),
+					resource.TestCheckResourceAttrSet(s.VnicResourceName, "public_ip_address"),
+					resource.TestMatchResourceAttr(s.VnicResourceName, "public_ip_address", regexp.MustCompile(`[0-9]+\.[0-9]+\.[0-9]+\.[0-9]`)),
+					resource.TestCheckResourceAttr(s.VnicResourceName, "hostname_label", "myvnichostname"),
+				),
+			},
+		},
+	})
+}
+
+func TestResourceCoreVnicAttachmentTestSuite(t *testing.T) {
+	suite.Run(t, new(ResourceCoreVnicAttachmentTestSuite))
+}

--- a/vendor/github.com/MustWin/baremetal-sdk-go/constants.go
+++ b/vendor/github.com/MustWin/baremetal-sdk-go/constants.go
@@ -155,6 +155,7 @@ const (
 	resourceInstances                resourceName = "instances"
 	resourceInternetGateways         resourceName = "internetGateways"
 	resourceIPSecConnections         resourceName = "ipsecConnections"
+	resourcePrivateIPs               resourceName = "privateIps"
 	resourceRouteTables              resourceName = "routeTables"
 	resourceSecurityLists            resourceName = "securityLists"
 	resourceShapes                   resourceName = "shapes"

--- a/vendor/github.com/MustWin/baremetal-sdk-go/core_private_ip.go
+++ b/vendor/github.com/MustWin/baremetal-sdk-go/core_private_ip.go
@@ -1,0 +1,111 @@
+package baremetal
+
+import (
+	"net/http"
+)
+
+type PrivateIP struct {
+	OPCRequestIDUnmarshaller
+	ETagUnmarshaller
+	AvailabilityDomain string `json:"availabilityDomain"`
+	CompartmentID      string `json:"compartmentId"`
+	DisplayName        string `json:"displayName"`
+	HostnameLabel      string `json:"hostnameLabel"`
+	ID                 string `json:"id"`
+	IPAddress          string `json:"ipAddress"`
+	IsPrimary          bool   `json:"isPrimary"`
+	SubnetID           string `json:"subnetId"`
+	TimeCreated        Time   `json:"timeCreated"`
+	VnicID             string `json:"vnicId"`
+}
+
+type ListPrivateIPs struct {
+	OPCRequestIDUnmarshaller
+	NextPageUnmarshaller
+	PrivateIPs []PrivateIP
+}
+
+func (l *ListPrivateIPs) GetList() interface{} {
+	return &l.PrivateIPs
+}
+
+func (c *Client) CreatePrivateIP(vnicID string, opts *CreatePrivateIPOptions) (privateIP *PrivateIP, e error) {
+	required := struct {
+		VnicId string `header:"-" json:"vnicId" url:"-"`
+	}{
+		VnicId: vnicID,
+	}
+
+	details := &requestDetails{
+		name:     resourcePrivateIPs,
+		optional: opts,
+		required: required,
+	}
+
+	var resp *response
+	if resp, e = c.coreApi.postRequest(details); e != nil {
+		return
+	}
+
+	privateIP = &PrivateIP{}
+	e = resp.unmarshal(privateIP)
+	return
+}
+
+func (c *Client) GetPrivateIP(id string) (privateIP *PrivateIP, e error) {
+	details := &requestDetails{
+		ids:  urlParts{id},
+		name: resourcePrivateIPs,
+	}
+
+	var resp *response
+	if resp, e = c.coreApi.getRequest(details); e != nil {
+		return
+	}
+
+	privateIP = &PrivateIP{}
+	e = resp.unmarshal(privateIP)
+	return
+}
+
+func (c *Client) UpdatePrivateIP(id string, opts *UpdatePrivateIPOptions) (privateIP *PrivateIP, e error) {
+	details := &requestDetails{
+		ids:      urlParts{id},
+		name:     resourcePrivateIPs,
+		optional: opts,
+	}
+
+	var resp *response
+	if resp, e = c.coreApi.request(http.MethodPut, details); e != nil {
+		return
+	}
+
+	privateIP = &PrivateIP{}
+	e = resp.unmarshal(privateIP)
+	return
+}
+
+func (c *Client) DeletePrivateIP(id string, opts *IfMatchOptions) (e error) {
+	details := &requestDetails{
+		ids:      urlParts{id},
+		name:     resourcePrivateIPs,
+		optional: opts,
+	}
+	return c.coreApi.deleteRequest(details)
+}
+
+func (c *Client) ListPrivateIPs(opts *ListPrivateIPsOptions) (privateIPs *ListPrivateIPs, e error) {
+	details := &requestDetails{
+		name:     resourcePrivateIPs,
+		optional: opts,
+	}
+
+	var resp *response
+	if resp, e = c.coreApi.getRequest(details); e != nil {
+		return
+	}
+
+	privateIPs = &ListPrivateIPs{}
+	e = resp.unmarshal(privateIPs)
+	return
+}

--- a/vendor/github.com/MustWin/baremetal-sdk-go/core_vnic.go
+++ b/vendor/github.com/MustWin/baremetal-sdk-go/core_vnic.go
@@ -2,6 +2,8 @@
 
 package baremetal
 
+import "net/http"
+
 // Vnic describes a virtual network interface.
 //
 // See https://docs.us-phoenix-1.oraclecloud.com/api/#/en/iaas/20160918/Vnic/
@@ -13,6 +15,8 @@ type Vnic struct {
 	DisplayName        string `json:"displayName"`
 	HostnameLabel      string `json:"hostnameLabel"`
 	ID                 string `json:"id"`
+	IsPrimary          bool   `json:"isPrimary"`
+	MacAddress         string `json:"macAddress"`
 	State              string `json:"lifecycleState"`
 	PrivateIPAddress   string `json:"privateIp"`
 	PublicIPAddress    string `json:"publicIp"`
@@ -37,5 +41,25 @@ func (c *Client) GetVnic(id string) (vnic *Vnic, e error) {
 
 	vnic = &Vnic{}
 	e = resp.unmarshal(vnic)
+	return
+}
+
+// UpdateVnic updates the specified VNIC.
+//
+// See https://docs.us-phoenix-1.oraclecloud.com/api/#/en/iaas/20160918/Vnic/UpdateVnic
+func (c *Client) UpdateVnic(id string, opts *UpdateVnicOptions) (res *Vnic, e error) {
+	details := &requestDetails{
+		ids:      urlParts{id},
+		name:     resourceVnics,
+		optional: opts,
+	}
+
+	var resp *response
+	if resp, e = c.coreApi.request(http.MethodPut, details); e != nil {
+		return
+	}
+
+	res = &Vnic{}
+	e = resp.unmarshal(res)
 	return
 }

--- a/vendor/github.com/MustWin/baremetal-sdk-go/request_options.go
+++ b/vendor/github.com/MustWin/baremetal-sdk-go/request_options.go
@@ -62,6 +62,12 @@ type CreatePreauthenticatedRequestDetails struct {
 	TimeExpires Time          `header:"-" json:"timeExpires" url:"-"`
 }
 
+type CreatePrivateIPOptions struct {
+	CreateOptions
+	HostnameLabel string `header:"-" json:"hostnameLabel,omitempty" url:"-"`
+	IPAddress     string `header:"-" json:"ipAddress,omitempty" url:"-"`
+}
+
 type CreateVcnOptions struct {
 	CreateOptions
 	DnsLabel string `header:"-" json:"dnsLabel,omitempty" url:"-"`
@@ -74,6 +80,10 @@ type CreateSubnetOptions struct {
 	ProhibitPublicIpOnVnic bool     `header:"-" json:"prohibitPublicIpOnVnic,omitempty" url:"-"`
 	RouteTableID           string   `header:"-" json:"routeTableId,omitempty" url:"-"`
 	SecurityListIDs        []string `header:"-" json:"securityListIds,omitempty" url:"-"`
+}
+
+type AttachVnicOptions struct {
+	CreateOptions
 }
 
 type LoadBalancerOptions struct {
@@ -135,6 +145,17 @@ type ListLoadBalancerOptions struct {
 type UpdateLoadBalancerOptions struct {
 	LoadBalancerOptions
 	DisplayNameOptions
+}
+
+type UpdatePrivateIPOptions struct {
+	UpdateOptions
+	HostnameLabel string `header:"-" json:"hostnameLabel,omitempty" url:"-"`
+	VnicID        string `header:"-" json:"vnicId,omitempty" url:"-"`
+}
+
+type UpdateVnicOptions struct {
+	UpdateOptions
+	HostnameLabel string `header:"-" json:"hostnameLabel,omitempty" url:"-"`
 }
 
 type CreateVolumeOptions struct {
@@ -331,6 +352,13 @@ type ListIPSecConnsOptions struct {
 	DrgIDListOptions
 	ListOptions
 	CpeID string `header:"-" json:"-" url:"cpeId,omitempty"`
+}
+
+type ListPrivateIPsOptions struct {
+	ListOptions
+	IPAddress string `header:"-" json:"-" url:"ipAddress,omitempty"`
+	SubnetID  string `header:"-" json:"-" url:"subnetId,omitempty"`
+	VnicID    string `header:"-" json:"-" url:"vnicId,omitempty"`
 }
 
 type ListShapesOptions struct {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -327,10 +327,10 @@
 			"revisionTime": "2017-02-01T00:43:30Z"
 		},
 		{
-			"checksumSHA1": "1sBxny1aMhcVDTZgCUs3EhX/LhU=",
+			"checksumSHA1": "smh/z9VKfGHJJA+QabEIrKhBg44=",
 			"path": "github.com/MustWin/baremetal-sdk-go",
-			"revision": "c0d7fef42dbb748248bfd6ec1acafa5f03071151",
-			"revisionTime": "2017-07-26T21:45:16Z"
+			"revision": "dce6978afc8d463aa13cd693e291a5df85f6ebb0",
+			"revisionTime": "2017-08-29T23:02:34Z"
 		},
 		{
 			"checksumSHA1": "Aqy8/FoAIidY/DeQ5oTYSZ4YFVc=",


### PR DESCRIPTION
Notes:
- Does not include VNIC update support. This can be added later.
- Updates subnet_id is instance resource to be options, allowing create_vnic_details to set this.
- The approach follows both the API and the approach taken for instance creation, where 
a VNIC attachment resource has a create_vnic_details property.